### PR TITLE
Remove unused react-scripts from server

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,7 +17,6 @@
         "nanoid": "^5.1.6",
         "nodemailer": "^8.0.3",
         "nodemon": "^3.1.14",
-        "react-scripts": "^0.0.0",
         "redis": "^5.11.0",
         "shortid": "^2.2.16",
         "socket.io": "^4.5.4"
@@ -1367,11 +1366,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/react-scripts": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-0.0.0.tgz",
-      "integrity": "sha512-W7cVfdhbIvYrTjVaryO7WCpvzODu8V7JH/1O36RcfuzP3Cxjp5WpX5ycaoGt0LSQpntrem5jFSUoJrtvru1reA=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -2756,11 +2750,6 @@
         "iconv-lite": "~0.4.24",
         "unpipe": "~1.0.0"
       }
-    },
-    "react-scripts": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-0.0.0.tgz",
-      "integrity": "sha512-W7cVfdhbIvYrTjVaryO7WCpvzODu8V7JH/1O36RcfuzP3Cxjp5WpX5ycaoGt0LSQpntrem5jFSUoJrtvru1reA=="
     },
     "readdirp": {
       "version": "3.6.0",

--- a/server/package.json
+++ b/server/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-  "start": "node index.js",
-  "dev": "nodemon index.js"
-},
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
   "author": "shunnu",
   "license": "ISC",
   "dependencies": {
@@ -19,7 +19,6 @@
     "nanoid": "^5.1.6",
     "nodemailer": "^8.0.3",
     "nodemon": "^3.1.14",
-    "react-scripts": "^0.0.0",
     "redis": "^5.11.0",
     "shortid": "^2.2.16",
     "socket.io": "^4.5.4"


### PR DESCRIPTION
Closes #4

Summary:
Removed unused react-scripts dependency from the server.

Changes:
- Removed react-scripts from server/package.json
- Updated package-lock.json

Verification:
- Confirmed no usage of react-scripts in server code
- Server runs successfully with npm start / npm run dev

This reduces confusion since the backend does not use CRA tooling.