### PR TITLE
Fix incorrect env path in frontend error messages

### DIFF
--- a/frontend/src/components/login/Login.jsx
+++ b/frontend/src/components/login/Login.jsx
@@ -124,7 +124,7 @@ function Login() {
     e.preventDefault();
     const { email, password } = user_values;
     if (!url) {
-      setalert_message("Missing REACT_APP_URL. Check client/.env.");
+      setalert_message("Missing REACT_APP_URL. Check frontend/.env.");
       setalert_box(true);
       return;
     }

--- a/frontend/src/components/register/Register.jsx
+++ b/frontend/src/components/register/Register.jsx
@@ -229,7 +229,7 @@ function Register() {
     let day = d.getDate();
 
     if (!url) {
-      setalert_message("Missing REACT_APP_URL. Check client/.env.");
+      setalert_message("Missing REACT_APP_URL. Check frontend/.env.");
       setalert_box(true);
       return;
     }


### PR DESCRIPTION
Closes #2 

Summary:
Updated incorrect environment file path in frontend error messages.

Changes:
- Replaced "client/.env" with "frontend/.env" in Login and Register components
- Ensured consistent wording across both files

Verification:
- Frontend builds successfully using npm run build
- Error message now points to the correct path

This prevents confusion for contributors setting up environment variables.