### PR TITLE
feat: add keyboard-friendly cancel (Escape key) for message editing Fixes #15

### DIFF
--- a/frontend/src/components/chat/messages/ValidChat.jsx
+++ b/frontend/src/components/chat/messages/ValidChat.jsx
@@ -290,7 +290,13 @@ function ValidChat() {
                           if (e.key === "Enter" && editingContent.trim()) {
                             editMessage(elem);
                           }
+                          // GSSoC Fix: Close edit mode on Escape key press
+                          if (e.key === "Escape") {
+                            setEditingTimestamp(null);
+                            setEditingContent("");
+                          }
                         }}
+                        autoFocus
                       />
                       <Button
                         type="button"


### PR DESCRIPTION
Problem:  Currently, once a user enters "Edit Mode" for a message, there is no quick way to cancel the action using the keyboard. Users have to manually click away or delete the text.

Solution:  I have added an onKeyDown event listener to the message input field.
Pressing Escape now successfully exits edit mode and reverts the content.
Added autoFocus to the input field so users can start typing/cancelling immediately without clicking again.

Testing:
Verified locally by triggering edit mode on a message and ensuring the Esc key reverts the UI to the original state.