### PR TITLE
fix: replace REACT_APP_ prefix with VITE_ for Vite compatibility

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,12 +1,9 @@
 # Frontend (Vite)
 # Backend base URL (Express)
-REACT_APP_URL="http://localhost:2000"
-
+VITE_URL="http://localhost:2000"
 # Frontend public base URL (used for invite links etc.)
-REACT_APP_front_end_url="http://localhost:5173"
-
+VITE_FRONT_END_URL="http://localhost:5173"
 # Supabase (profile photo uploads)
-REACT_APP_SUPABASE_URL="https://<project>.supabase.co"
-REACT_APP_SUPABASE_ANON_KEY="<anon-key>"
-REACT_APP_SUPABASE_BUCKET="<bucket-name>"
-
+VITE_SUPABASE_URL="https://<project>.supabase.co"
+VITE_SUPABASE_ANON_KEY="<anon-key>"
+VITE_SUPABASE_BUCKET="<bucket-name>"

--- a/frontend/src/components/auth/Auth.jsx
+++ b/frontend/src/components/auth/Auth.jsx
@@ -7,7 +7,7 @@ const Auth = () => {
   const [auth_check, setauth_check] = useState(null);
   const [token, setToken] = useState(() => localStorage.getItem("token"));
 
-  const url = process.env.REACT_APP_URL;
+  const url = import.meta.env.VITE_URL;
 
   const private_routes = useCallback(async () => {
     if (!url || !token) {

--- a/frontend/src/components/chat/messages/ValidChat.jsx
+++ b/frontend/src/components/chat/messages/ValidChat.jsx
@@ -9,7 +9,7 @@ import { Button } from "../../ui/button";
 
 function ValidChat() {
   const dispatch = useDispatch();
-  const url = process.env.REACT_APP_URL;
+  const url = import.meta.env.VITE_URL;
   const { server_id } = useParams();
 
   // channel creds from redux

--- a/frontend/src/components/chat/serverDetails/ServerDetails.jsx
+++ b/frontend/src/components/chat/serverDetails/ServerDetails.jsx
@@ -20,7 +20,7 @@ function ServerDetails({ new_req_recieved, elem, onNavigate }) {
   const [selectedValue, setSelectedValue] = useState("text");
   const [category_name, setcategory_name] = useState("");
   const [new_channel_name, setnew_channel_name] = useState("");
-  const url = process.env.REACT_APP_URL;
+  const url = import.meta.env.VITE_URL;
   const [channel_creation_progess, setchannel_creation_progess] = useState({
     text: "Create Channel",
     disabled: false,

--- a/frontend/src/components/chat/serverSidebar/Navbar2ChatValid.jsx
+++ b/frontend/src/components/chat/serverSidebar/Navbar2ChatValid.jsx
@@ -33,7 +33,7 @@ function Navbar2ChatValid({ onNavigate }) {
   const id = useSelector((state) => state.user_info.id);
   const activeChannelId = useSelector((state) => state.currentPage.page_id);
 
-  const front_end_url = process.env.REACT_APP_front_end_url;
+  const front_end_url = import.meta.env.VITE_FRONT_END_URL;
 
   const [show, setShow] = useState(false);
   const handleClose = () => {

--- a/frontend/src/components/invite/Invite.jsx
+++ b/frontend/src/components/invite/Invite.jsx
@@ -13,7 +13,7 @@ function Invite() {
   const { username, tag, profile_pic, id } = user_creds || {};
 
   const { invite_link } = useParams();
-  const url = process.env.REACT_APP_URL;
+  const url = import.meta.env.VITE_URL;
   const [invite_details, setinvite_details] = useState(null);
   const [invalid_invite_link, setinvalid_invite_link] = useState(null);
 

--- a/frontend/src/components/login/Login.jsx
+++ b/frontend/src/components/login/Login.jsx
@@ -109,7 +109,7 @@ function Login() {
   const [alert_box, setalert_box] = useState(false);
   const [alert_message, setalert_message] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const url = process.env.REACT_APP_URL;
+  const url = import.meta.env.VITE_URL;
 
   const canSubmit = useMemo(
     () => user_values.email.trim().length > 0 && user_values.password.length > 0,
@@ -124,7 +124,7 @@ function Login() {
     e.preventDefault();
     const { email, password } = user_values;
     if (!url) {
-      setalert_message("Missing REACT_APP_URL. Check frontend/.env.");
+      setalert_message("Missing VITE_URL. Check frontend/.env.");
       setalert_box(true);
       return;
     }

--- a/frontend/src/components/navbar/Navbar.jsx
+++ b/frontend/src/components/navbar/Navbar.jsx
@@ -103,7 +103,7 @@ function Navbar({ new_req_recieved, user_cred, onNavigate }) {
   const create_server = async () => {
     const image_url = await upload_server_image();
 
-    const res = await fetch(`${process.env.REACT_APP_URL}/create_server`, {
+    const res = await fetch(`${import.meta.env.VITE_URL}/create_server`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/frontend/src/components/notifications/NotificationListener.jsx
+++ b/frontend/src/components/notifications/NotificationListener.jsx
@@ -21,7 +21,7 @@ function NotificationListener() {
   const userId = useSelector((state) => state.user_info.id);
   const activeFriend = useSelector((state) => state.direct_message.activeFriend);
   const activeChannelId = useSelector((state) => state.currentPage.page_id);
-  const url = process.env.REACT_APP_URL;
+  const url = import.meta.env.VITE_URL;
 
   const pathParts = location.pathname.split("/");
   const activeServerId = pathParts[2];

--- a/frontend/src/components/register/Register.jsx
+++ b/frontend/src/components/register/Register.jsx
@@ -193,7 +193,7 @@ function Register() {
     "January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December",
   ];
-  const url = process.env.REACT_APP_URL;
+  const url = import.meta.env.VITE_URL;
 
   const canSubmit = useMemo(
     () =>
@@ -229,7 +229,7 @@ function Register() {
     let day = d.getDate();
 
     if (!url) {
-      setalert_message("Missing REACT_APP_URL. Check frontend/.env.");
+      setalert_message("Missing VITE_URL. Check frontend/.env.");
       setalert_box(true);
       return;
     }

--- a/frontend/src/components/socket/Socket.jsx
+++ b/frontend/src/components/socket/Socket.jsx
@@ -1,4 +1,4 @@
 import socketIO from "socket.io-client";
-const url = process.env.REACT_APP_URL;
+const url = import.meta.env.VITE_URL;
 let socket = socketIO.connect(url);
 export default socket;

--- a/frontend/src/config/index.js
+++ b/frontend/src/config/index.js
@@ -1,2 +1,1 @@
-export const API_BASE_URL = process.env.REACT_APP_URL || "";
-
+export const API_BASE_URL = import.meta.env.VITE_URL || "";

--- a/frontend/src/lib/supabaseClient.js
+++ b/frontend/src/lib/supabaseClient.js
@@ -1,12 +1,12 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase =
   supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null;
 
 export function getSupabaseBucket() {
-  return process.env.REACT_APP_SUPABASE_BUCKET || "server-icons";
+  return import.meta.env.VITE_SUPABASE_BUCKET || "server-icons";
 }
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,30 +1,14 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), "");
-
-  const processEnvShim = {
-    REACT_APP_URL: env.REACT_APP_URL || env.VITE_API_URL || "",
-    REACT_APP_front_end_url:
-      env.REACT_APP_front_end_url || env.VITE_FRONTEND_URL || "",
-    REACT_APP_SUPABASE_URL: env.REACT_APP_SUPABASE_URL || "",
-    REACT_APP_SUPABASE_ANON_KEY: env.REACT_APP_SUPABASE_ANON_KEY || "",
-    REACT_APP_SUPABASE_BUCKET: env.REACT_APP_SUPABASE_BUCKET || "",
-  };
-
-  return {
-    plugins: [react(), tailwindcss()],
-    define: {
-      "process.env": processEnvShim,
-    },
-    server: {
-      port: 5173,
-      strictPort: true,
-    },
-    build: {
-      sourcemap: false
-    }
-  };
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
+  build: {
+    sourcemap: false,
+  },
 });


### PR DESCRIPTION
Fixes #27

## What changed
Replaced all `process.env.REACT_APP_` references with `import.meta.env.VITE_` 
across the frontend codebase, and updated `.env.example` with the correct 
VITE_ prefixed variable names.

## Files changed
- `frontend/.env.example` - renamed all variables to VITE_ prefix
- `frontend/src/config/index.js`
- `frontend/src/lib/supabaseClient.js`
- `frontend/src/components/auth/Auth.jsx`
- `frontend/src/components/chat/messages/ValidChat.jsx`
- `frontend/src/components/chat/serverDetails/ServerDetails.jsx`
- `frontend/src/components/chat/serverSidebar/Navbar2ChatValid.jsx`
- `frontend/src/components/invite/Invite.jsx`
- `frontend/src/components/login/Login.jsx`
- `frontend/src/components/navbar/Navbar.jsx`
- `frontend/src/components/notifications/NotificationListener.jsx`
- `frontend/src/components/register/Register.jsx`
- `frontend/src/components/socket/Socket.jsx`

## Why
Vite only exposes env variables prefixed with `VITE_`. Variables with 
`REACT_APP_` prefix are silently ignored, causing API calls to fall 
back to hardcoded localhost values.