### PR TITLE
fix: render OTP verification errors inside modal

### DIFF
--- a/frontend/src/components/register/Register.jsx
+++ b/frontend/src/components/register/Register.jsx
@@ -177,6 +177,8 @@ function Register() {
   const [modalShow, setModalShow] = useState(false);
   const [alert_box, setalert_box] = useState(false);
   const [alert_message, setalert_message] = useState("");
+  const [otp_alert_box, setotp_alert_box] = useState(false);
+  const [otp_alert_message, setotp_alert_message] = useState(""); 
   const [date_validation, setdate_validation] = useState(false);
   const [user_values, setuser_values] = useState({
     date_value: "",
@@ -210,7 +212,13 @@ function Register() {
     setuser_values((v) => ({ ...v, [e.target.name]: e.target.value }));
   };
 
-  const handle_otp = (e) => setotp_value(e.target.value);
+  const handle_otp = (e) => {
+    setotp_value(e.target.value);
+
+  if (otp_alert_box) {
+    setotp_alert_box(false);
+  }
+};
 
   useEffect(() => {
     const min_date = new Date().getFullYear();
@@ -281,7 +289,7 @@ function Register() {
     if (!url) return;
     try {
       setVerifying(true);
-      setalert_box(false);
+      setotp_alert_box(false);
       const res = await fetch(`${url}/verify`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -291,52 +299,66 @@ function Register() {
       if (data.status === 201) {
         setModalShow(false);
         setotp_value("");
+        setotp_alert_box(false);
         Navigate("/");
       } else if (data.status === 432) {
-        setalert_message("Incorrect code. Please try again.");
-        setalert_box(true);
+        setotp_alert_message("Incorrect code. Please try again.");
+        setotp_alert_box(true);
       } else if (data.status === 442) {
-        setalert_message("Code expired. A new one has been sent to your email.");
-        setalert_box(true);
+        setotp_alert_message("Code expired. A new one has been sent to your email.");
+        setotp_alert_box(true);
       } else {
-        setalert_message("Verification failed. Please try again.");
-        setalert_box(true);
+        setotp_alert_message("Verification failed. Please try again.");
+        setotp_alert_box(true);
       }
     } catch {
-      setalert_message("Network error. Please try again.");
-      setalert_box(true);
+      setotp_alert_message("Network error. Please try again.");
+      setotp_alert_box(true);
     } finally {
       setVerifying(false);
     }
   };
+  
+const resend_otp = async () => {
+  if (!url) return;
 
-  const resend_otp = async () => {
-    if (!url) return;
-    try {
-      setVerifying(true);
-      const res = await fetch(`${url}/resend_otp`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: user_values.email }),
-      });
-      const data = await res.json();
-      if (data.status === 201) {
-        setalert_message(
-          data.email_sent === false
-            ? "Couldn't send email. Please try again."
-            : "New code sent! Check your inbox."
-        );
-      } else {
-        setalert_message("Could not resend code. Please try again.");
-      }
-      setalert_box(true);
-    } catch {
-      setalert_message("Network error. Please try again.");
-      setalert_box(true);
-    } finally {
-      setVerifying(false);
+  try {
+    setVerifying(true);
+    setotp_alert_box(false);
+
+    const res = await fetch(`${url}/resend_otp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: user_values.email }),
+    });
+
+    const data = await res.json();
+
+    if (data.status === 201) {
+      setotp_alert_message(
+        data.email_sent === false
+          ? "Couldn't send email. Please try again."
+          : "New code sent! Check your inbox."
+      );
+    } else {
+      setotp_alert_message(
+        "Could not resend code. Please try again."
+      );
     }
-  };
+
+    setotp_alert_box(true);
+
+  } catch {
+    setotp_alert_message(
+      "Network error. Please try again."
+    );
+
+    setotp_alert_box(true);
+
+  } finally {
+    setVerifying(false);
+  }
+};
 
   return (
     <>
@@ -526,7 +548,10 @@ function Register() {
         onOpenChange={(open) => {
           if (verifying) return;
           setModalShow(open);
-          if (!open) setotp_value("");
+          if (!open) {
+          setotp_value("");
+          setotp_alert_box(false);
+          }
         }}
       >
         <DialogContent
@@ -565,7 +590,12 @@ function Register() {
               {user_values.email}
             </span>
           </DialogDescription>
-
+            {otp_alert_box && (
+              <AlertBanner
+               message={otp_alert_message}
+               onClose={() => setotp_alert_box(false)}
+             />
+            )}
           <form onSubmit={verify_req} className="mt-5 space-y-4">
             <div>
               <Label>Verification Code</Label>
@@ -587,6 +617,7 @@ function Register() {
                   if (verifying) return;
                   setModalShow(false);
                   setotp_value("");
+                  setotp_alert_box(false);
                 }}
                 disabled={verifying}
               >


### PR DESCRIPTION
Summary

This PR fixes the OTP verification UX issue where verification-related errors were rendered behind the modal using the shared registration AlertBanner state.

Changes Made
Added modal-specific OTP alert state
Rendered OTP verification errors inside the verification dialog
Updated resend OTP error handling
Cleared stale OTP errors on input change and modal close
Result

Users can now immediately see OTP-related errors directly inside the verification modal without closing the dialog.

Closes #32