### PR TITLE
fix: ignore transient Vite timestamp files in frontend linting

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,7 @@ import jsxA11y from "eslint-plugin-jsx-a11y";
 
 export default [
   {
-    ignores: ["dist/**", "node_modules/**"],
+    ignores: ["dist/**", "node_modules/**", "vite.config.js.timestamp-*.mjs"],
   },
   js.configs.recommended,
   {


### PR DESCRIPTION
Fixes #3

### Description
This PR fixes the issue where `npm run lint` in the frontend would occasionally fail with an `ENOENT` error because ESLint attempted to read transient Vite configuration files (like `vite.config.js.timestamp-*.mjs`).

### Changes Made:
- Updated the `ignores` array in `frontend/eslint.config.js` to include `"vite.config.js.timestamp-*.mjs"`.
- Ensured that existing ignore patterns (`"dist/**"` and `"node_modules/**"`) were preserved.

### Verification:
Running `npm run lint` now completes successfully without getting interrupted by generated timestamp files.
