### PR TITLE
fix(auth): move verification email errors into OTP modal

### DIFF
--- a/frontend/src/components/register/Register.jsx
+++ b/frontend/src/components/register/Register.jsx
@@ -177,6 +177,8 @@ function Register() {
   const [modalShow, setModalShow] = useState(false);
   const [alert_box, setalert_box] = useState(false);
   const [alert_message, setalert_message] = useState("");
+  const [otp_alert_box, setotp_alert_box] = useState(false);
+  const [otp_alert_message, setotp_alert_message] = useState("");
   const [date_validation, setdate_validation] = useState(false);
   const [user_values, setuser_values] = useState({
     date_value: "",
@@ -250,9 +252,12 @@ function Register() {
         const data = await res.json();
         if (data.status === 201) {
           if (data.email_sent === false) {
-            setalert_message("We couldn't send the verification email. Click Resend.");
-            setalert_box(true);
+            setotp_alert_message(
+              "We couldn't send the verification email. Click Resend."
+            );
+            setotp_alert_box(true);
           }
+
           setModalShow(true);
         } else if (data.status === 202) {
           setalert_message("An account with this email already exists.");
@@ -281,7 +286,7 @@ function Register() {
     if (!url) return;
     try {
       setVerifying(true);
-      setalert_box(false);
+      setotp_alert_box(false);
       const res = await fetch(`${url}/verify`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -291,20 +296,24 @@ function Register() {
       if (data.status === 201) {
         setModalShow(false);
         setotp_value("");
+        setModalShow(false);
+        setotp_value("");
         Navigate("/");
       } else if (data.status === 432) {
-        setalert_message("Incorrect code. Please try again.");
-        setalert_box(true);
+        setotp_alert_message("Incorrect code. Please try again.");
+        setotp_alert_box(true);
       } else if (data.status === 442) {
-        setalert_message("Code expired. A new one has been sent to your email.");
-        setalert_box(true);
+        setotp_alert_message(
+          "Code expired. A new one has been sent to your email."
+        );
+        setotp_alert_box(true);
       } else {
-        setalert_message("Verification failed. Please try again.");
-        setalert_box(true);
+        setotp_alert_message("Verification failed. Please try again.");
+        setotp_alert_box(true);
       }
     } catch {
-      setalert_message("Network error. Please try again.");
-      setalert_box(true);
+      setotp_alert_message("Network error. Please try again.");
+      setotp_alert_box(true);
     } finally {
       setVerifying(false);
     }
@@ -321,18 +330,18 @@ function Register() {
       });
       const data = await res.json();
       if (data.status === 201) {
-        setalert_message(
+        setotp_alert_message(
           data.email_sent === false
             ? "Couldn't send email. Please try again."
             : "New code sent! Check your inbox."
         );
       } else {
-        setalert_message("Could not resend code. Please try again.");
+        setotp_alert_message("Could not resend code. Please try again.");
       }
-      setalert_box(true);
+      setotp_alert_box(true);
     } catch {
-      setalert_message("Network error. Please try again.");
-      setalert_box(true);
+      setotp_alert_message("Network error. Please try again.");
+      setotp_alert_box(true);
     } finally {
       setVerifying(false);
     }
@@ -526,7 +535,11 @@ function Register() {
         onOpenChange={(open) => {
           if (verifying) return;
           setModalShow(open);
-          if (!open) setotp_value("");
+          if (!open) {
+            setotp_value("");
+            setotp_alert_box(false);
+            setotp_alert_message("");
+          }
         }}
       >
         <DialogContent
@@ -565,7 +578,14 @@ function Register() {
               {user_values.email}
             </span>
           </DialogDescription>
-
+          {otp_alert_box && (
+            <div className="mt-4">
+              <AlertBanner
+                message={otp_alert_message}
+                onClose={() => setotp_alert_box(false)}
+              />
+            </div>
+          )}
           <form onSubmit={verify_req} className="mt-5 space-y-4">
             <div>
               <Label>Verification Code</Label>


### PR DESCRIPTION
## Summary
- What changed?
    - The OTP Verification email errors are now being displayed in the OTP modal itself
- Why is this needed?
    - Previously we needed to close the OTP modal to know if there is any error. The user would try to type the OTP, or resend OTP but even if the OTP could not be sent or OTP was incorrect, the user would not know before he could close the modal and then see the errors in the registeration card.

## Related Issue
Closes #32 

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tooling / developer experience

## Validation
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [ ] Server starts with `cd server && npm start`, if backend code changed
- [x] I checked the feature or page I changed in the app

## Screenshots or Recording

### Before:

1. When OTP could'nt be sent - The modal for entring the OTP would open but no error is shown
<img width="1919" height="909" alt="image" src="https://github.com/user-attachments/assets/ece617bc-1334-41e4-97fb-ba2d3d3df487" />

Error can be seen only when we close the modal
<img width="1919" height="916" alt="image" src="https://github.com/user-attachments/assets/8499a8df-9831-46f5-9ee7-370cef8d42aa" />

2. When OTP is incorrect - After entering wrong OTP in the modal no error is shown
<img width="1919" height="916" alt="image" src="https://github.com/user-attachments/assets/c4794c88-3c66-4971-8aab-db8aade8185a" />

Error can be seen only when we close the modal
<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/af45cc9a-5da1-4e33-bc5b-f152aeccec79" />


### After:

1. When OTP couldn't be sent
<img width="1919" height="917" alt="image" src="https://github.com/user-attachments/assets/a75ebf6a-06bc-42a6-9046-1b3ec1da8462" />

4. When OTP is incorrect
<img width="1919" height="915" alt="image" src="https://github.com/user-attachments/assets/02eb8f49-573c-4c67-aa70-2b85a146241b" />

## Notes for Reviewers
AI Usage : Used for writing the commit message. AI was not used in any way to write code or generate content for the PR description. Thanks!