### PR TITLE
fix: add 404 page for unknown frontend routes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import {
 } from "react-router-dom";
 import Invite from "./components/invite/Invite";
 import NotificationListener from "./components/notifications/NotificationListener";
+import NotFound from "./components/notFound/NotFound";
 import { AnimatePresence } from "framer-motion";
 
 function AnimatedRoutes() {
@@ -24,6 +25,7 @@ function AnimatedRoutes() {
           <Route path="/channels/:server_id" element={<Dashboard />}></Route>
           <Route path="/invite/:invite_link" element={<Invite />}></Route>
         </Route>
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </AnimatePresence>
   );

--- a/frontend/src/components/notFound/NotFound.jsx
+++ b/frontend/src/components/notFound/NotFound.jsx
@@ -1,0 +1,69 @@
+import { Link as RouterLink } from "react-router-dom";
+import AuthShell from "../auth/AuthShell";
+import { motion } from "framer-motion";
+
+function PrimaryButton({ children, ...props }) {
+  return (
+    <motion.button
+      whileHover={{ scale: 1.015 }}
+      whileTap={{ scale: 0.985 }}
+      transition={{ duration: 0.15 }}
+      className="w-full h-12 rounded-xl text-sm font-bold tracking-wide transition-all duration-200"
+      style={{
+        background: "linear-gradient(135deg, #a855f7 0%, #7c3aed 100%)",
+        color: "#fff",
+        border: "none",
+        cursor: "pointer",
+        boxShadow: "0 4px 24px rgba(124,58,237,0.4), inset 0 1px 0 rgba(255,255,255,0.15)",
+        letterSpacing: "0.04em",
+      }}
+      {...props}
+    >
+      {children}
+    </motion.button>
+  );
+}
+
+function NotFound() {
+  return (
+    <AuthShell mode="notfound">
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 8 }}
+        transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+        className="space-y-6"
+      >
+        <div className="flex flex-col items-center gap-3 text-center">
+          <div>
+            <h1
+              className="text-4xl font-black tracking-tight mb-2"
+              style={{ color: "#f0f0f5" }}
+            >
+              404
+            </h1>
+            <h2
+              className="text-xl font-semibold tracking-tight"
+              style={{ color: "#f0f0f5" }}
+            >
+              Page Not Found
+            </h2>
+            <p className="text-sm mt-2" style={{ color: "rgba(255,255,255,0.4)" }}>
+              The page you&apos;re looking for doesn&apos;t exist.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex justify-center">
+          <RouterLink to="/" className="w-full max-w-xs">
+            <PrimaryButton>
+              Go Home
+            </PrimaryButton>
+          </RouterLink>
+        </div>
+      </motion.div>
+    </AuthShell>
+  );
+}
+
+export default NotFound;

--- a/frontend/src/components/notFound/NotFound.jsx
+++ b/frontend/src/components/notFound/NotFound.jsx
@@ -1,5 +1,4 @@
 import { Link as RouterLink } from "react-router-dom";
-import AuthShell from "../auth/AuthShell";
 import { motion } from "framer-motion";
 
 function PrimaryButton({ children, ...props }) {
@@ -26,43 +25,92 @@ function PrimaryButton({ children, ...props }) {
 
 function NotFound() {
   return (
-    <AuthShell mode="notfound">
+    <div
+      className="relative min-h-screen w-full flex items-center justify-center overflow-hidden"
+      style={{ background: "#0a0a0f" }}
+    >
+      {/* Gradient overlays matching AuthShell design */}
+      <div
+        className="pointer-events-none absolute"
+        style={{
+          top: "-20%",
+          left: "-10%",
+          width: "55%",
+          height: "70%",
+          background:
+            "radial-gradient(ellipse at center, rgba(124,58,237,0.18) 0%, transparent 70%)",
+          filter: "blur(40px)",
+        }}
+      />
+      <div
+        className="pointer-events-none absolute"
+        style={{
+          bottom: "-15%",
+          right: "-10%",
+          width: "50%",
+          height: "60%",
+          background:
+            "radial-gradient(ellipse at center, rgba(217,119,6,0.12) 0%, transparent 70%)",
+          filter: "blur(50px)",
+        }}
+      />
+      <div
+        className="pointer-events-none absolute"
+        style={{
+          top: "40%",
+          left: "35%",
+          width: "30%",
+          height: "40%",
+          background:
+            "radial-gradient(ellipse at center, rgba(16,185,129,0.07) 0%, transparent 70%)",
+          filter: "blur(60px)",
+        }}
+      />
+
+      {/* Noise texture */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E")`,
+          opacity: 0.4,
+        }}
+      />
+
+      {/* Content */}
       <motion.div
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: 8 }}
         transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
-        className="space-y-6"
+        className="relative z-10 space-y-6 w-full max-w-md px-4 text-center"
       >
-        <div className="flex flex-col items-center gap-3 text-center">
-          <div>
-            <h1
-              className="text-4xl font-black tracking-tight mb-2"
-              style={{ color: "#f0f0f5" }}
-            >
-              404
-            </h1>
-            <h2
-              className="text-xl font-semibold tracking-tight"
-              style={{ color: "#f0f0f5" }}
-            >
-              Page Not Found
-            </h2>
-            <p className="text-sm mt-2" style={{ color: "rgba(255,255,255,0.4)" }}>
-              The page you&apos;re looking for doesn&apos;t exist.
-            </p>
-          </div>
+        <div className="flex flex-col items-center gap-3">
+          <h1
+            className="text-6xl font-black tracking-tight"
+            style={{ color: "#f0f0f5" }}
+          >
+            404
+          </h1>
+          <h2
+            className="text-2xl font-semibold tracking-tight"
+            style={{ color: "#f0f0f5" }}
+          >
+            Page Not Found
+          </h2>
+          <p className="text-sm mt-2" style={{ color: "rgba(255,255,255,0.4)" }}>
+            The page you&apos;re looking for doesn&apos;t exist.
+          </p>
         </div>
 
-        <div className="flex justify-center">
-          <RouterLink to="/" className="w-full max-w-xs">
+        <div className="pt-4">
+          <RouterLink to="/" className="w-full block">
             <PrimaryButton>
               Go Home
             </PrimaryButton>
           </RouterLink>
         </div>
       </motion.div>
-    </AuthShell>
+    </div>
   );
 }
 


### PR DESCRIPTION

<img width="1920" height="1200" alt="Screenshot (1039)" src="https://github.com/user-attachments/assets/b71c6a4a-90d3-457f-94bf-af59e4bad1fb" />

Fixes #50 
## Summary
Added a catch-all route and a custom 404 page for invalid frontend URLs.

## Changes
- Added `frontend/src/components/notFound/NotFound.jsx`
- Added `path="*"` route in `frontend/src/App.jsx`
- Styled the page to match the existing PipeChat UI
- Added a "Go Home" button for navigation

## Verification
- Invalid routes now show the 404 page
- Existing routes still work correctly
- "Go Home" redirects to `/`