### PR TITLE
fix: socket auth + stop trusting client for sender identity (#52)

### DIFF
--- a/frontend/src/components/socket/Socket.jsx
+++ b/frontend/src/components/socket/Socket.jsx
@@ -1,4 +1,7 @@
 import socketIO from "socket.io-client";
 const url = process.env.REACT_APP_URL;
-let socket = socketIO.connect(url);
+const token = localStorage.getItem("token");
+let socket = socketIO.connect(url, {
+  auth: { token },
+});
 export default socket;

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -1,3 +1,5 @@
+import jwt from "jsonwebtoken";
+
 const onlineUsers = new Map();
 
 function emitPresenceSnapshot(socket) {
@@ -49,15 +51,27 @@ function setUserOffline(io, userId, socketId) {
 }
 
 function attachSocketHandlers(io) {
+  io.use((socket, next) => {
+    const token = socket.handshake.auth.token;
+    if (!token) return next(new Error("Authentication required"));
+    try {
+      const decoded = jwt.verify(token, process.env.ACCESS_TOKEN);
+      socket.data.user = decoded; // { id, username, tag, profile_pic }
+      next();
+    } catch (err) {
+      next(new Error("Invalid token"));
+    }
+  });
+
+  
   io.on("connection", (socket) => {
     socket.on("channelCreated", (data) => {
       io.emit("newChannel", data);
     });
-  });
 
-  io.on("connection", (socket) => {
-    socket.on("get_userid", (user_id) => {
-      const normalizedUserId = String(user_id);
+    socket.on("get_userid", () => {
+       
+      const normalizedUserId = String(socket.data.user.id);
 
       if (socket.data.user_id === normalizedUserId) {
         socket.join(normalizedUserId);
@@ -121,21 +135,19 @@ function attachSocketHandlers(io) {
       socket.data.server_id = normalizedServerId;
       socket.join(`server:${normalizedServerId}`);
     });
-
-    socket.on(
-      "send_message",
-      (channel_id, message, timestamp, sender_name, sender_tag, sender_pic) => {
-        socket.to(channel_id).emit("recieve_message", {
-          message_data: {
-            message,
-            timestamp,
-            sender_name,
-            sender_tag,
-            sender_pic,
-          },
-        });
-      }
-    );
+ 
+    socket.on("send_message", (channel_id, message, timestamp) => {
+      const { username, tag, profile_pic } = socket.data.user;
+      socket.to(channel_id).emit("recieve_message", {
+        message_data: {
+          message,
+          timestamp,
+          sender_name: username,
+          sender_tag: tag,
+          sender_pic: profile_pic,
+        },
+      });
+    });
 
     socket.on("disconnect", () => {
       setUserOffline(io, socket.data.user_id, socket.id);


### PR DESCRIPTION
Fixes #52

While going through the socket code I noticed two things that 
stood out:

1. The socket connection had zero authentication anyone could 
connect and start emitting events with no verification at all.

2. send_message was taking sender_name, sender_tag, sender_pic 
directly from the client payload and forwarding them as-is. 
Basically anyone could put any name/pic and impersonate someone.

What I changed:

- Added a Socket.IO middleware (io.use) that checks the JWT token 
from the handshake before the connection is established. If the 
token is missing or invalid, the connection is rejected.

- send_message now ignores the client-provided sender fields and 
instead reads username, tag, profile_pic from the verified token 
stored in socket.data.user

- get_userid no longer trusts the user_id sent by the client 
uses the verified ID from the token instead

- Also merged the two separate io.on("connection") blocks into 
one since having them split serves no purpose

Files changed:
- server/socket/index.js
- frontend/src/components/socket/Socket.jsx

Note: join_chat membership check (also mentioned in #52) needs 
DB queries to verify server membership I can follow up on that 
separately if needed.

Tested locally socket connects with token, messages show 
correct sender info.