### PR TITLE
fix: use VITE_SUPABASE_* env vars instead of REACT_APP_* in Vite project

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Server runs on `http://localhost:2000`
 | ----------------------------- | -------: | -------------------------------------- |
 | `REACT_APP_URL`               |       ✅ | Backend URL (`http://localhost:2000`)  |
 | `REACT_APP_front_end_url`     |       ✅ | Frontend URL (`http://localhost:5173`) |
-| `REACT_APP_SUPABASE_URL`      |       ❌ | For avatar uploads                     |
-| `REACT_APP_SUPABASE_ANON_KEY` |       ❌ | For avatar uploads                     |
-| `REACT_APP_SUPABASE_BUCKET`   |       ❌ | For avatar uploads                     |
+| `VITE_SUPABASE_URL`           |       ❌ | For avatar uploads                     |
+| `VITE_SUPABASE_ANON_KEY`      |       ❌ | For avatar uploads                     |
+| `VITE_SUPABASE_BUCKET`        |       ❌ | For avatar uploads                     |
 
 ## Scripts
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,7 +6,7 @@ REACT_APP_URL="http://localhost:2000"
 REACT_APP_front_end_url="http://localhost:5173"
 
 # Supabase (profile photo uploads)
-REACT_APP_SUPABASE_URL="https://<project>.supabase.co"
-REACT_APP_SUPABASE_ANON_KEY="<anon-key>"
-REACT_APP_SUPABASE_BUCKET="<bucket-name>"
+VITE_SUPABASE_URL="https://<project>.supabase.co"
+VITE_SUPABASE_ANON_KEY="<anon-key>"
+VITE_SUPABASE_BUCKET="<bucket-name>"
 

--- a/frontend/src/lib/supabaseClient.js
+++ b/frontend/src/lib/supabaseClient.js
@@ -1,12 +1,12 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase =
   supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null;
 
 export function getSupabaseBucket() {
-  return process.env.REACT_APP_SUPABASE_BUCKET || "server-icons";
+  return import.meta.env.VITE_SUPABASE_BUCKET || "server-icons";
 }
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,9 +9,6 @@ export default defineConfig(({ mode }) => {
     REACT_APP_URL: env.REACT_APP_URL || env.VITE_API_URL || "",
     REACT_APP_front_end_url:
       env.REACT_APP_front_end_url || env.VITE_FRONTEND_URL || "",
-    REACT_APP_SUPABASE_URL: env.REACT_APP_SUPABASE_URL || "",
-    REACT_APP_SUPABASE_ANON_KEY: env.REACT_APP_SUPABASE_ANON_KEY || "",
-    REACT_APP_SUPABASE_BUCKET: env.REACT_APP_SUPABASE_BUCKET || "",
   };
 
   return {


### PR DESCRIPTION
Vite exposes env variables via import.meta.env with the VITE_ prefix, not via process.env with REACT_APP_* names. Using the wrong prefix meant supabaseUrl and supabaseAnonKey were always undefined, causing the Supabase client to be silently null and profile photo uploads to never work.

Changes:
- frontend/src/lib/supabaseClient.js: switch all three reads from process.env.REACT_APP_SUPABASE_* to import.meta.env.VITE_SUPABASE_*
- frontend/vite.config.js: remove the dead REACT_APP_SUPABASE_* shim entries that were mapping undefined values into the process.env shim
- frontend/.env.example: rename the three keys to VITE_SUPABASE_*
- README.md: update the frontend env table to reflect the new key names