### PR TITLE
feat: improve homepage feature card visibility and contrast

### DIFF
--- a/frontend/src/components/auth/AuthShell.jsx
+++ b/frontend/src/components/auth/AuthShell.jsx
@@ -123,19 +123,26 @@ export default function AuthShell({ children}) {
               ].map((item) => (
                 <motion.div
                   key={item.label}
-                  whileHover={{ y: -3, scale: 1.02 }}
+                  whileHover={{
+                        y: -5,
+                        scale: 1.03,
+                        boxShadow: "0 12px 30px rgba(124,58,237,0.18)"
+                  }}
                   transition={{ duration: 0.2 }}
-                  className="rounded-2xl p-4 cursor-default"
-                  style={{
-                    background: "rgba(255,255,255,0.03)",
-                    border: "1px solid rgba(255,255,255,0.07)",
+                  className="rounded-2xl p-4 cursor-pointer hover:border-violet-400/30"
+                  style={{ 
+                    background: "rgba(255,255,255,0.06)",
+                    border: "1px solid rgba(255,255,255,0.12)",
+                    boxShadow: "0 8px 24px rgba(0,0,0,0.25)",
+                    transition: "all 0.3s ease",
+
                   }}
                 >
                   <div className="text-xl mb-2">{item.icon}</div>
                   <div className="text-xs font-bold" style={{ color: "rgba(255,255,255,0.85)" }}>
                     {item.label}
                   </div>
-                  <div className="text-xs mt-0.5" style={{ color: "rgba(255,255,255,0.35)" }}>
+                  <div className="text-xs mt-0.5" style={{ color: "rgba(255,255,255,0.65))" }}>
                     {item.sub}
                   </div>
                 </motion.div>


### PR DESCRIPTION
## Description

Enhanced the homepage feature cards section to improve visibility, readability, contrast, and overall user interaction while maintaining the existing dark-themed aesthetic of PiperChat.

Previously, the feature cards blended into the background due to very low background opacity and weak border contrast. The subtitle text was also difficult to read on darker screens, making the section feel visually flat and less interactive.

## Improvements Made

* Increased card background opacity for better separation from the dark background
* Improved border visibility to make cards more distinguishable
* Enhanced subtitle text contrast for improved readability and accessibility
* Added smoother hover interactions and subtle elevation effects for better UI feedback
* Improved visual hierarchy while preserving the original design language
* Maintained responsiveness and consistency across different screen sizes

## Before

* Cards appeared too dim against the dark background
* Text readability was reduced due to low contrast
* Hover interactions felt minimal and less engaging
* Overall section lacked visual depth and clarity

## After

* Cards are now more visually distinct and easier to read
* Improved contrast makes content more accessible
* Hover interactions provide clearer visual feedback
* Section feels cleaner, more polished, and more interactive without changing the original UI aesthetic

## Screenshots

### Before

<img width="1270" height="943" alt="image" src="https://github.com/user-attachments/assets/662b4a36-6156-4173-9b5e-0d4e068c5937" />


### After

<img width="694" height="469" alt="image" src="https://github.com/user-attachments/assets/9a30a5b4-d62c-4fd6-b9c9-df10af789d45" />



## Testing

* Tested locally on desktop view
* Verified responsiveness and visual consistency
* Ensured no layout breaking changes were introduced


Fixes #74
