### PR TITLE
feat(email): integrated Resend provider with resilient OTP delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,12 +10,29 @@ ACCESS_TOKEN="<long-random-string>"
 # Default profile picture URL used on signup
 default_profile_pic="https://example.com/default_profile_avatar.png"
 
-# Email (Gmail App Password or SMTP). Pick ONE approach:
-# - Gmail App Password:
+# Email / OTP delivery (provider priority: console → Resend → SMTP → Gmail)
+#
+# Local dev & automated tests — log OTP to the server console (no real email):
+# MAIL_TRANSPORT=console
+#
+# Resend (recommended): https://resend.com
+# Sandbox: only sends to your Resend account email until a domain is verified.
+RESEND_API_KEY=""
+RESEND_FROM_EMAIL="PiperChat <onboarding@resend.dev>"
+# RESEND_SEND_TIMEOUT_MS=10000
+#
+# Generic SMTP (e.g. Mailgun, SendGrid SMTP, corporate relay)
+# SMTP_HOST=""
+# SMTP_PORT=587
+# SMTP_SECURE=false
+# SMTP_USER=""
+# SMTP_PASS=""
+#
+# Gmail App Password:
 MAIL_USER="you@gmail.com"
 MAIL_PASS="<gmail-app-password>"
-
-# - Or OAuth2 (optional)
+#
+# Gmail OAuth2 (optional alternative to app password)
 OAUTH_CLIENTID=""
 OAUTH_CLIENT_SECRET=""
 OAUTH_REFRESH_TOKEN=""

--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ Server runs on `http://localhost:2000`
 | `ACCESS_TOKEN`                                                   |       ✅ | JWT secret                             |
 | `PORT`                                                           |       ❌ | Default `2000`                         |
 | `default_profile_pic`                                            |       ✅ | Used on signup                         |
-| `MAIL_USER` / `MAIL_PASS`                                        |       ✅ | Gmail App Password flow                |
-| `OAUTH_CLIENTID` / `OAUTH_CLIENT_SECRET` / `OAUTH_REFRESH_TOKEN` |       ❌ | Optional OAuth2 email sending          |
+| `RESEND_API_KEY` / `RESEND_FROM_EMAIL`                           |       ❌ | **Recommended** transactional email (Resend); use `onboarding@resend.dev` locally |
+| `MAIL_TRANSPORT`                                                   |       ❌ | Set to `console` to log OTPs without sending (local/tests) |
+| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS`          |       ❌ | Generic SMTP fallback                  |
+| `MAIL_USER` / `MAIL_PASS`                                        |       ❌ | Gmail App Password fallback            |
+| `OAUTH_CLIENTID` / `OAUTH_CLIENT_SECRET` / `OAUTH_REFRESH_TOKEN` |       ❌ | Gmail OAuth2 fallback                  |
 | `REDIS_URL`                                                      |       ❌ | Upstash URL supported (`rediss://...`) |
 | `REDIS_CACHE_TTL_SECONDS`                                        |       ❌ | Default `30`                           |
 
@@ -128,6 +131,23 @@ cd server
 npm ci
 ```
 
-Backend tests are not included yet because the backend does not currently have a
-test script. Once backend tests are added, the CI workflow can be extended to run
-`npm test` inside `server/`.
+Backend auth checks (including signup/verify with console mail transport):
+
+```bash
+cd server
+npm run test:auth
+```
+
+### Email / OTP configuration
+
+OTP emails are sent through `server/services/email.js`. Configure **one** provider; the server picks the first match in this order:
+
+1. `MAIL_TRANSPORT=console` — logs the OTP to the server console (no delivery). Used by `npm run test:auth`.
+2. `RESEND_API_KEY` — [Resend](https://resend.com) (preferred for production). Set `RESEND_FROM_EMAIL` to a verified sender (e.g. `PiperChat <onboarding@resend.dev>` for sandbox). Until you verify a domain, Resend only delivers to the email address on your Resend account.
+3. `SMTP_HOST` + credentials — any SMTP relay.
+4. `MAIL_USER` + `MAIL_PASS` — Gmail app password.
+5. `OAUTH_*` — Gmail OAuth2.
+
+If nothing is configured, signup and resend still work but responses include `email_sent: false`.
+
+Backend tests are not included in CI yet beyond dependency install. Run `npm run test:auth` locally before changing auth or email behavior.

--- a/frontend/src/components/login/Login.jsx
+++ b/frontend/src/components/login/Login.jsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { Link as RouterLink, useLocation, useNavigate } from "react-router-dom";
 import AuthShell from "../auth/AuthShell";
 import { motion, AnimatePresence } from "framer-motion";
+import { postJson } from "../../lib/api.js";
 
 
 function Label({ children }) {
@@ -131,12 +132,7 @@ function Login() {
     try {
       setSubmitting(true);
       setalert_box(false);
-      const res = await fetch(`${url}/signin`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password }),
-      });
-      const data = await res.json();
+      const { data } = await postJson(url, "/signin", { email, password });
       if (data.status === 442) {
         setalert_message("Invalid email or password.");
         setalert_box(true);
@@ -152,8 +148,8 @@ function Login() {
         setalert_message("Login failed. Please try again.");
         setalert_box(true);
       }
-    } catch {
-      setalert_message("Network error. Please try again.");
+    } catch (err) {
+      setalert_message(err?.message || "Network error. Please try again.");
       setalert_box(true);
     } finally {
       setSubmitting(false);

--- a/frontend/src/components/register/Register.jsx
+++ b/frontend/src/components/register/Register.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
+import { postJson } from "../../lib/api.js";
 import AuthShell from "../auth/AuthShell";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -244,12 +245,13 @@ function Register() {
       try {
         setSubmitting(true);
         setalert_box(false);
-        const res = await fetch(`${url}/signup`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email, password, username, dob }),
+        const { data } = await postJson(url, "/signup", {
+          email,
+          password,
+          username,
+          dob,
         });
-        const data = await res.json();
+
         if (data.status === 201) {
           if (data.email_sent === false) {
             setotp_alert_message(
@@ -268,12 +270,15 @@ function Register() {
         } else if (data.status === 400) {
           setalert_message("Password must be at least 7 characters long.");
           setalert_box(true);
+        } else if (data.status === 500) {
+          setalert_message("Server error. Please try again in a moment.");
+          setalert_box(true);
         } else {
           setalert_message("Registration failed. Please try again.");
           setalert_box(true);
         }
-      } catch {
-        setalert_message("Network error. Please try again.");
+      } catch (err) {
+        setalert_message(err?.message || "Network error. Please try again.");
         setalert_box(true);
       } finally {
         setSubmitting(false);
@@ -287,12 +292,10 @@ function Register() {
     try {
       setVerifying(true);
       setotp_alert_box(false);
-      const res = await fetch(`${url}/verify`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ otp_value: otp_value.trim(), email: user_values.email }),
+      const { data } = await postJson(url, "/verify", {
+        otp_value: otp_value.trim(),
+        email: user_values.email,
       });
-      const data = await res.json();
       if (data.status === 201) {
         setModalShow(false);
         setotp_value("");
@@ -311,8 +314,8 @@ function Register() {
         setotp_alert_message("Verification failed. Please try again.");
         setotp_alert_box(true);
       }
-    } catch {
-      setotp_alert_message("Network error. Please try again.");
+    } catch (err) {
+      setotp_alert_message(err?.message || "Network error. Please try again.");
       setotp_alert_box(true);
     } finally {
       setVerifying(false);
@@ -323,12 +326,9 @@ function Register() {
     if (!url) return;
     try {
       setVerifying(true);
-      const res = await fetch(`${url}/resend_otp`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: user_values.email }),
+      const { data } = await postJson(url, "/resend_otp", {
+        email: user_values.email,
       });
-      const data = await res.json();
       if (data.status === 201) {
         setotp_alert_message(
           data.email_sent === false
@@ -339,8 +339,8 @@ function Register() {
         setotp_alert_message("Could not resend code. Please try again.");
       }
       setotp_alert_box(true);
-    } catch {
-      setotp_alert_message("Network error. Please try again.");
+    } catch (err) {
+      setotp_alert_message(err?.message || "Network error. Please try again.");
       setotp_alert_box(true);
     } finally {
       setVerifying(false);

--- a/frontend/src/components/socket/Socket.jsx
+++ b/frontend/src/components/socket/Socket.jsx
@@ -1,6 +1,6 @@
 import socketIO from "socket.io-client";
 const url = import.meta.env.VITE_URL;
 let socket = socketIO.connect(url, {
-  transports: ["websocket"],
+  transports: ["websocket", "polling"],
 });
 export default socket;

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -23,7 +23,8 @@ export async function postJson(baseUrl, path, body, options = {}) {
     if (text) {
       try {
         data = JSON.parse(text);
-      } catch {
+      } catch (parseErr) {
+        console.error(`[api] JSON parse failed for ${url}:`, text, parseErr);
         const preview = text.replace(/\s+/g, " ").slice(0, 120);
         throw new Error(
           `Server returned non-JSON (${res.status}): ${preview || "(empty)"}`

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,48 @@
+/**
+ * POST JSON to the backend with timeout and safe body parsing.
+ * Throws Error with a user-facing message; never throws on non-JSON alone.
+ */
+export async function postJson(baseUrl, path, body, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const url = `${String(baseUrl).replace(/\/$/, "")}${path}`;
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    const text = await res.text();
+    let data = {};
+
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        const preview = text.replace(/\s+/g, " ").slice(0, 120);
+        throw new Error(
+          `Server returned non-JSON (${res.status}): ${preview || "(empty)"}`
+        );
+      }
+    }
+
+    return { res, data };
+  } catch (err) {
+    if (err?.name === "AbortError") {
+      throw new Error("Request timed out. Is the server running on the correct port?");
+    }
+    if (err instanceof TypeError && /fetch/i.test(err.message)) {
+      throw new Error(
+        "Cannot reach the server. Check that the backend is running and VITE_URL is correct."
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,27 @@ import { setIO } from "./socket/runtime.js";
 const port = process.env.PORT || 2000;
 const app = express();
 
-app.use(cors());
+const allowedOrigins = (
+  process.env.FRONTEND_ORIGINS ||
+  "http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173"
+)
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+app.use(
+  cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+      callback(new Error(`CORS blocked origin: ${origin}`));
+    },
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "x-auth-token"],
+  })
+);
 app.use(express.json({ limit: "10kb" }));
 app.use(express.urlencoded({ extended: true, limit: "10kb" }));
 
@@ -37,20 +57,42 @@ app.use("/", directMessageRoutes);
 app.use("/", notificationRoutes);
 app.use("/", profileRoutes);
 
+app.use((err, req, res, next) => {
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
+
+  if (err?.type === "entity.parse.failed") {
+    return res.status(400).json({
+      ok: false,
+      message: "Invalid JSON body",
+      status: 400,
+    });
+  }
+
+  if (err?.message?.startsWith("CORS blocked origin")) {
+    return res.status(403).json({
+      ok: false,
+      message: err.message,
+      status: 403,
+    });
+  }
+
+  console.error("[server] Unhandled error:", err?.message || err);
+  return res.status(500).json({
+    ok: false,
+    message: "Server error",
+    status: 500,
+  });
+});
+
 async function start() {
   await connect();
   const server = app.listen(port, () => {
     console.log(`listening on port ${port}`);
     console.log("Connected to DB");
   });
-
-  const allowedOrigins = (
-    process.env.FRONTEND_ORIGINS ||
-    "http://localhost:3000,http://localhost:5173"
-  )
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
 
   const io = new SocketIOServer(server, {
     pingTimeout: 20000,

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+import http from "http";
 import "./config/env.js";
 import cors from "cors";
 import express from "express";
@@ -89,19 +90,25 @@ app.use((err, req, res, next) => {
 
 async function start() {
   await connect();
-  const server = app.listen(port, () => {
-    console.log(`listening on port ${port}`);
-    console.log("Connected to DB");
-  });
+
+  const server = http.createServer(app);
 
   const io = new SocketIOServer(server, {
     pingTimeout: 20000,
     cors: {
       origin: allowedOrigins,
+      methods: ["GET", "POST"],
+      credentials: true,
     },
   });
+
   setIO(io);
   attachSocketHandlers(io);
+
+  server.listen(port, () => {
+    console.log(`listening on port ${port}`);
+    console.log("Connected to DB");
+  });
 }
 
 start().catch((err) => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,6 +19,7 @@
         "nodemailer": "^8.0.3",
         "nodemon": "^3.1.14",
         "redis": "^5.11.0",
+        "resend": "^6.12.3",
         "shortid": "^2.2.16",
         "socket.io": "^4.5.4"
       },
@@ -107,6 +108,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@types/cors": {
@@ -791,6 +798,12 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1844,6 +1857,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1933,6 +1952,27 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/safe-buffer": {
@@ -2259,6 +2299,16 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2289,6 +2339,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/tar-stream": {
@@ -2527,6 +2586,11 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
+    "@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
     },
     "@types/cors": {
       "version": "2.8.19",
@@ -2986,6 +3050,11 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true
+    },
+    "fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
     },
     "fill-range": {
       "version": "7.1.1",
@@ -3638,6 +3707,11 @@
         "find-up": "^4.0.0"
       }
     },
+    "postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3699,6 +3773,15 @@
         "@redis/json": "5.11.0",
         "@redis/search": "5.11.0",
         "@redis/time-series": "5.11.0"
+      }
+    },
+    "resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "requires": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
       }
     },
     "safe-buffer": {
@@ -3916,6 +3999,15 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "requires": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3938,6 +4030,14 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "requires": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "tar-stream": {

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "start": "node index.js",
     "dev": "nodemon index.js",
     "test:auth:unit": "node scripts/run-auth-jwt-unit.mjs",
-    "test:auth": "node scripts/run-auth-integration.mjs"
+    "test:auth": "node scripts/run-auth-integration.mjs",
+    "verify:resend": "node scripts/verify-resend-integration.mjs"
   },
   "author": "shunnu",
   "license": "ISC",
@@ -23,6 +24,7 @@
     "nodemailer": "^8.0.3",
     "nodemon": "^3.1.14",
     "redis": "^5.11.0",
+    "resend": "^6.12.3",
     "shortid": "^2.2.16",
     "socket.io": "^4.5.4"
   },

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -73,6 +73,8 @@ router.post("/verify_route", authToken, (req, res) => {
 
 router.post("/signup", async (req, res) => {
   const startedAt = Date.now();
+  const reqId = Math.random().toString(36).slice(2, 10);
+  console.log(`[auth/signup][${reqId}] → received request`);
   try {
     const { email, username, password, dob } = req.body ?? {};
     const authorized = false;
@@ -114,6 +116,7 @@ router.post("/signup", async (req, res) => {
 
       try {
         await newUser.save();
+        console.log(`[auth/signup][${reqId}] user saved successfully`);
       } catch (err) {
         console.error("[auth/signup] Failed to save user:", err?.message || err);
         return signupJson(res, 500, {
@@ -123,6 +126,7 @@ router.post("/signup", async (req, res) => {
         });
       }
 
+      console.log(`[auth/signup][${reqId}] starting background email send`);
       sendVerificationEmailAsync(otp, email, username, "signup");
 
       return signupJson(res, 201, {
@@ -221,9 +225,7 @@ router.post("/signup", async (req, res) => {
       });
     }
   } finally {
-    if (process.env.SIGNUP_DEBUG === "true") {
-      console.info(`[auth/signup] completed in ${Date.now() - startedAt}ms`);
-    }
+    console.info(`[auth/signup][${reqId}] completed in ${Date.now() - startedAt}ms`);
   }
 });
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -16,6 +16,27 @@ import {
 
 const router = express.Router();
 
+function sendVerificationEmailAsync(otp, email, username, context = "signup") {
+  sendMail(otp, email, username)
+    .then((mailResult) => {
+      if (!mailResult.ok) {
+        console.warn(`[auth/${context}] Verification email not sent:`, {
+          email,
+          reason: mailResult.reason,
+          provider: mailResult.provider,
+          error: mailResult.error?.message,
+        });
+      }
+    })
+    .catch((err) => {
+      console.error(`[auth/${context}] sendMail error:`, err?.message || err);
+    });
+}
+
+function signupJson(res, status, payload) {
+  return res.status(status).json({ ok: status >= 200 && status < 300, ...payload });
+}
+
 function looksLikeBcryptHash(storedPassword) {
   return (
     typeof storedPassword === "string" &&
@@ -51,135 +72,158 @@ router.post("/verify_route", authToken, (req, res) => {
 });
 
 router.post("/signup", async (req, res) => {
-  const { email, username, password, dob } = req.body;
-  const authorized = false;
+  const startedAt = Date.now();
+  try {
+    const { email, username, password, dob } = req.body ?? {};
+    const authorized = false;
 
-  const response = await signup(email, username, password, dob);
+    const response = await signup(email, username, password, dob);
 
-  if (
-    response.status === 204 ||
-    response.status === 400 ||
-    response.status === 202
-  ) {
-    return res
-      .status(response.status)
-      .json({ message: response.message, status: response.status });
-  }
-
-  if (typeof password !== "string" || password.length === 0) {
-    return res.status(204).json({ message: "wrong input", status: 204 });
-  }
-
-  const hashedPassword = await bcrypt.hash(password, 10);
-
-  if (response.message === true) {
-    const otp = generateOTP();
-    const usernameResponse = await isUsernameAvailable(username);
-    const finalTag = usernameResponse.final_tag;
-
-
-    const newUser = new User({
-      username,
-      tag: finalTag,
-      profile_pic: process.env.default_profile_pic,
-      email,
-      password: hashedPassword,
-      dob,
-      authorized,
-      verification: [{ timestamp: Date.now(), code: otp }],
-    });
-
-    const mailResult = await sendMail(otp, email, username);
-    try {
-      await newUser.save();
-    } catch (err) {
-      return res
-        .status(500)
-        .json({ message: "Server error", status: 500, email_sent: false });
+    if (
+      response.status === 204 ||
+      response.status === 400 ||
+      response.status === 202
+    ) {
+      return signupJson(res, response.status, {
+        message: response.message,
+        status: response.status,
+      });
     }
-    return res.status(201).json({
-      message: "data saved",
-      status: 201,
-      email_sent: mailResult.ok,
-    });
-  }
 
-  if (response.message === "not_TLE" || response.message === "TLE_2") {
-    const usernameResponse = await isUsernameAvailable(username);
-    const tag = usernameResponse.final_tag;
-    const accountCreds = {
-      $set: {
+    if (typeof password !== "string" || password.length === 0) {
+      return signupJson(res, 204, { message: "wrong input", status: 204 });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    if (response.message === true) {
+      const otp = generateOTP();
+      const usernameResponse = await isUsernameAvailable(username);
+      const finalTag = usernameResponse.final_tag;
+
+      const newUser = new User({
         username,
-        tag,
+        tag: finalTag,
+        profile_pic: process.env.default_profile_pic,
         email,
         password: hashedPassword,
         dob,
         authorized,
-      },
-    };
-    let otp = response.message === "not_TLE" ? response.otp : generateOTP();
-    const newResponse = await updatingCreds(
-      accountCreds,
-      otp,
-      email,
-      username
-    );
-    return res
-      .status(newResponse.status)
-      .json({
-        message: newResponse.message,
-        status: newResponse.status,
-        email_sent: Boolean(newResponse.mailResult?.ok),
+        verification: [{ timestamp: Date.now(), code: otp }],
       });
-  }
 
-  if (response.message === "not_TLE_2" || response.message === "TLE") {
-    const tag = response.tag;
-    let accountCreds;
-    let otp;
+      try {
+        await newUser.save();
+      } catch (err) {
+        console.error("[auth/signup] Failed to save user:", err?.message || err);
+        return signupJson(res, 500, {
+          message: "Server error",
+          status: 500,
+          email_sent: false,
+        });
+      }
 
-    if (response.message === "not_TLE_2") {
-      accountCreds = {
-        $set: {
-          username,
-          tag,
-          email,
-          password: hashedPassword,
-          dob,
-          authorized,
-        },
-      };
-      otp = response.otp;
-    } else {
-      otp = generateOTP();
-      accountCreds = {
-        $set: {
-          username,
-          email,
-          tag,
-          password: hashedPassword,
-          dob,
-          authorized,
-          verification: [
-            { timestamp: Date.now(), code: otp },
-          ],
-        },
-      };
+      sendVerificationEmailAsync(otp, email, username, "signup");
+
+      return signupJson(res, 201, {
+        message: "data saved",
+        status: 201,
+        email_sent: null,
+      });
     }
 
-    const newResponse = await updatingCreds(
-      accountCreds,
-      otp,
-      email,
-      username
-    );
-    return res
-      .status(newResponse.status)
-      .json({
+    if (response.message === "not_TLE" || response.message === "TLE_2") {
+      const usernameResponse = await isUsernameAvailable(username);
+      const tag = usernameResponse.final_tag;
+      const accountCreds = {
+        $set: {
+          username,
+          tag,
+          email,
+          password: hashedPassword,
+          dob,
+          authorized,
+        },
+      };
+      const otp =
+        response.message === "not_TLE" ? response.otp : generateOTP();
+      const newResponse = await updatingCreds(
+        accountCreds,
+        otp,
+        email,
+        username
+      );
+      return signupJson(res, newResponse.status, {
         message: newResponse.message,
         status: newResponse.status,
-        email_sent: Boolean(newResponse.mailResult?.ok),
+        email_sent: null,
       });
+    }
+
+    if (response.message === "not_TLE_2" || response.message === "TLE") {
+      const tag = response.tag;
+      let accountCreds;
+      let otp;
+
+      if (response.message === "not_TLE_2") {
+        accountCreds = {
+          $set: {
+            username,
+            tag,
+            email,
+            password: hashedPassword,
+            dob,
+            authorized,
+          },
+        };
+        otp = response.otp;
+      } else {
+        otp = generateOTP();
+        accountCreds = {
+          $set: {
+            username,
+            email,
+            tag,
+            password: hashedPassword,
+            dob,
+            authorized,
+            verification: [{ timestamp: Date.now(), code: otp }],
+          },
+        };
+      }
+
+      const newResponse = await updatingCreds(
+        accountCreds,
+        otp,
+        email,
+        username
+      );
+      return signupJson(res, newResponse.status, {
+        message: newResponse.message,
+        status: newResponse.status,
+        email_sent: null,
+      });
+    }
+
+    console.warn("[auth/signup] Unhandled signup branch:", response);
+    return signupJson(res, 500, {
+      message: "Server error",
+      status: 500,
+      email_sent: false,
+    });
+  } catch (err) {
+    console.error("[auth/signup] Unhandled error:", err?.message || err);
+    if (!res.headersSent) {
+      return signupJson(res, 500, {
+        message: "Server error",
+        status: 500,
+        email_sent: false,
+      });
+    }
+  } finally {
+    if (process.env.SIGNUP_DEBUG === "true") {
+      console.info(`[auth/signup] completed in ${Date.now() - startedAt}ms`);
+    }
   }
 });
 
@@ -217,7 +261,7 @@ router.post("/verify", async (req, res) => {
         },
       }
     );
-    await sendMail(otp, email, username);
+    sendVerificationEmailAsync(otp, email, username, "verify");
     return res.status(442).json({ error: "otp changed", status: 442 });
   } catch (err) {
     return res.status(500).json({ error: "Server error", status: 500 });
@@ -242,11 +286,11 @@ router.post("/resend_otp", async (req, res) => {
       { email },
       { $set: { verification: [{ timestamp: Date.now(), code: otp }] } }
     );
-    const mailResult = await sendMail(otp, email, username);
+    sendVerificationEmailAsync(otp, email, username, "resend_otp");
     return res.status(201).json({
       message: "otp resent",
       status: 201,
-      email_sent: mailResult.ok,
+      email_sent: null,
     });
   } catch (err) {
     return res.status(500).json({ error: "Server error", status: 500 });

--- a/server/scripts/verify-resend-integration.mjs
+++ b/server/scripts/verify-resend-integration.mjs
@@ -1,0 +1,261 @@
+/**
+ * Local Resend integration verification (Issue #44).
+ * Run from repo: node server/scripts/verify-resend-integration.mjs
+ */
+import { spawn } from "child_process";
+import express from "express";
+import http from "http";
+import mongoose from "mongoose";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import "../config/env.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SANDBOX_EMAIL = "amritasahu490@gmail.com";
+const results = [];
+
+function pass(name, detail = "") {
+  results.push({ name, ok: true, detail });
+  console.log(`✓ ${name}${detail ? `: ${detail}` : ""}`);
+}
+
+function fail(name, detail = "") {
+  results.push({ name, ok: false, detail });
+  console.error(`✗ ${name}${detail ? `: ${detail}` : ""}`);
+}
+
+function runChild(scriptLines) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--input-type=module", "-e", scriptLines],
+      {
+        cwd: path.join(__dirname, ".."),
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      }
+    );
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (err += d));
+    child.on("close", (code) => {
+      resolve({ code, out: out.trim(), err: err.trim() });
+    });
+    child.on("error", reject);
+  });
+}
+
+async function testImportsAndProvider() {
+  if (process.env.MAIL_TRANSPORT === "console") {
+    fail("MAIL_TRANSPORT", "MAIL_TRANSPORT=console is set — disable for Resend test");
+    return;
+  }
+  pass("MAIL_TRANSPORT", "not console");
+
+  if (!process.env.RESEND_API_KEY?.trim()) {
+    fail("RESEND_API_KEY", "missing");
+    return;
+  }
+  pass("RESEND_API_KEY", "configured");
+
+  const from =
+    process.env.RESEND_FROM_EMAIL?.trim() || "PiperChat <onboarding@resend.dev>";
+  pass("RESEND_FROM_EMAIL", from);
+
+  await import("resend");
+  pass("resend package import");
+
+  const { sendMail } = await import("../services/email.js");
+  const result = await sendMail("8888", SANDBOX_EMAIL, "ResendVerify");
+
+  if (result.provider !== "resend") {
+    fail("provider resolution", `expected resend, got ${result.provider}`);
+    return;
+  }
+  pass("provider resolution", "resend");
+
+  if (!result.ok) {
+    fail("Resend API send", result.error?.message || "unknown");
+    return;
+  }
+  pass("Resend API send", `email id ${result.info?.id}`);
+}
+
+async function testSignupAndAuth() {
+  const { connect } = await import("../config/db.js");
+  const authRoutes = (await import("../routes/auth.js")).default;
+  const User = (await import("../models/User.js")).default;
+
+  await connect();
+
+  const username = `resend_${Date.now().toString().slice(-6)}`;
+  const password = "ResendTest99";
+
+  await User.deleteOne({ email: SANDBOX_EMAIL });
+
+  const app = express();
+  app.use(express.json());
+  app.use("/", authRoutes);
+
+  const server = http.createServer(app);
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  try {
+    const t0 = Date.now();
+    const signupRes = await fetch(`${base}/signup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: SANDBOX_EMAIL,
+        username,
+        password,
+        dob: "January 1 , 2000",
+      }),
+    });
+    const signupBody = await signupRes.json();
+    const signupMs = Date.now() - t0;
+
+    if (signupRes.status !== 201) {
+      fail("signup", `${signupRes.status} ${JSON.stringify(signupBody)}`);
+      return;
+    }
+    pass("signup", `201 in ${signupMs}ms (email async)`);
+
+    await new Promise((r) => setTimeout(r, 5000));
+
+    const user = await User.findOne({ email: SANDBOX_EMAIL }).lean();
+    const otp = user?.verification?.[0]?.code;
+    if (!otp || otp.length !== 4) {
+      fail("OTP generation", "missing verification code in DB");
+      return;
+    }
+    pass("OTP generation", `code saved (check inbox for OTP)`);
+
+    const verifyRes = await fetch(`${base}/verify`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: SANDBOX_EMAIL, otp_value: otp }),
+    });
+    const verifyBody = await verifyRes.json();
+    if (verifyRes.status !== 201) {
+      fail("verify", `${verifyRes.status} ${JSON.stringify(verifyBody)}`);
+    } else {
+      pass("verify", "account authorized");
+    }
+
+    const signinRes = await fetch(`${base}/signin`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: SANDBOX_EMAIL, password }),
+    });
+    const signinBody = await signinRes.json();
+    if (signinRes.status === 201 && signinBody.token) {
+      pass("signin", "JWT issued");
+    } else {
+      fail("signin", `${signinRes.status} ${JSON.stringify(signinBody)}`);
+    }
+
+    await User.updateOne(
+      { email: SANDBOX_EMAIL },
+      { $set: { authorized: false } }
+    );
+
+    const resendRes = await fetch(`${base}/resend_otp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: SANDBOX_EMAIL }),
+    });
+    if (resendRes.status === 201) {
+      pass("resend_otp", "201 — check inbox for new OTP");
+    } else {
+      fail("resend_otp", `${resendRes.status}`);
+    }
+  } finally {
+    server.close();
+    await mongoose.disconnect();
+  }
+}
+
+async function testConsoleFallback() {
+  const { code, out, err } = await runChild(`
+    import './config/env.js';
+    process.env.MAIL_TRANSPORT = 'console';
+    delete process.env.RESEND_API_KEY;
+    const { sendMail } = await import('./services/email.js');
+    const r = await sendMail('1111', '${SANDBOX_EMAIL}', 't');
+    console.log(JSON.stringify(r));
+  `);
+  if (code !== 0) {
+    fail("console transport (child)", err || out);
+    return;
+  }
+  const result = JSON.parse(out.split("\n").pop());
+  if (result.provider === "console" && result.ok) {
+    pass("console transport (child)", "console provider");
+  } else {
+    fail("console transport (child)", out);
+  }
+}
+
+async function testGmailFallbackWithoutResend() {
+  const { code, out, err } = await runChild(`
+    import './config/env.js';
+    delete process.env.MAIL_TRANSPORT;
+    delete process.env.RESEND_API_KEY;
+    const { sendMail } = await import('./services/email.js');
+    const r = await sendMail('2222', 'other@example.com', 't');
+    console.log(JSON.stringify(r));
+  `);
+  if (code !== 0) {
+    fail("Gmail fallback (child)", err || out);
+    return;
+  }
+  const result = JSON.parse(out.split("\n").pop());
+  if (result.provider === "gmail" || result.reason === "send_failed") {
+    pass(
+      "Gmail fallback (child)",
+      `Resend skipped; nodemailer used (${result.provider || result.reason})`
+    );
+  } else if (result.reason === "mail_not_configured") {
+    pass("Gmail fallback (child)", "mail_not_configured");
+  } else {
+    fail("Gmail fallback (child)", out);
+  }
+}
+
+async function main() {
+  console.log("=== PiperChat Resend integration verification ===\n");
+  console.log(`Sandbox recipient: ${SANDBOX_EMAIL}`);
+  console.log(
+    "Manual checks: inbox/spam + https://resend.com/emails for delivery status\n"
+  );
+
+  await testImportsAndProvider();
+  await testSignupAndAuth();
+  await testConsoleFallback();
+  await testGmailFallbackWithoutResend();
+
+  const failed = results.filter((r) => !r.ok);
+  console.log(
+    `\n=== ${results.length - failed.length}/${results.length} automated checks passed ===`
+  );
+
+  if (failed.length) {
+    console.log("\nFailed:");
+    for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
+    process.exit(1);
+  }
+
+  console.log(
+    "\nIssue #44 core objective: Resend is active provider; direct send + auth flows OK."
+  );
+  console.log("Confirm delivery in Resend dashboard and amritasahu490@gmail.com inbox.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/server/services/email.js
+++ b/server/services/email.js
@@ -1,79 +1,316 @@
 import nodemailer from "nodemailer";
+import { Resend } from "resend";
 
 const emailUser = process.env.EMAIL_USER || process.env.MAIL_USER;
+const DEFAULT_RESEND_FROM = "PiperChat <onboarding@resend.dev>";
+const RESEND_SEND_TIMEOUT_MS = Number(
+  process.env.RESEND_SEND_TIMEOUT_MS || 10_000
+);
 
-function createTransporter() {
-  if (process.env.MAIL_TRANSPORT === "console") {
-    return null;
+/** @typedef {"console" | "resend" | "smtp" | "gmail" | "gmail-oauth"} EmailProvider */
+
+let resendClient;
+
+function isConsoleTransport() {
+  return process.env.MAIL_TRANSPORT === "console";
+}
+
+function hasResendConfig() {
+  return Boolean(process.env.RESEND_API_KEY?.trim());
+}
+
+function hasSmtpConfig() {
+  const smtpUser = process.env.SMTP_USER || emailUser;
+  const smtpPass = process.env.SMTP_PASS || process.env.MAIL_PASS;
+  return Boolean(process.env.SMTP_HOST && smtpUser && smtpPass);
+}
+
+function hasGmailPasswordConfig() {
+  return Boolean(emailUser && process.env.MAIL_PASS);
+}
+
+function hasGmailOAuthConfig() {
+  return Boolean(
+    emailUser &&
+      process.env.OAUTH_CLIENTID &&
+      process.env.OAUTH_CLIENT_SECRET &&
+      process.env.OAUTH_REFRESH_TOKEN
+  );
+}
+
+/**
+ * Provider priority: console → Resend → SMTP → Gmail password → Gmail OAuth.
+ * @returns {EmailProvider | null}
+ */
+function resolveEmailProvider() {
+  if (isConsoleTransport()) {
+    return "console";
+  }
+  if (hasResendConfig()) {
+    return "resend";
+  }
+  if (hasSmtpConfig()) {
+    return "smtp";
+  }
+  if (hasGmailPasswordConfig()) {
+    return "gmail";
+  }
+  if (hasGmailOAuthConfig()) {
+    return "gmail-oauth";
+  }
+  return null;
+}
+
+function getResendClient() {
+  if (!resendClient && hasResendConfig()) {
+    resendClient = new Resend(process.env.RESEND_API_KEY);
+  }
+  return resendClient;
+}
+
+function getFromAddress() {
+  const configured =
+    process.env.RESEND_FROM_EMAIL?.trim() ||
+    process.env.MAIL_FROM?.trim() ||
+    emailUser;
+
+  if (!configured) {
+    return DEFAULT_RESEND_FROM;
   }
 
-  const smtpHost = process.env.SMTP_HOST;
+  if (configured.includes("<") || configured.includes("@")) {
+    return configured.includes("<")
+      ? configured
+      : `PiperChat <${configured}>`;
+  }
+
+  return DEFAULT_RESEND_FROM;
+}
+
+function withTimeout(promise, timeoutMs, label) {
+  let settled = false;
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    promise
+      .then((value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch((error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}
+
+function normalizeResendError(error) {
+  if (!error) {
+    return { message: "Unknown Resend error" };
+  }
+
+  if (typeof error === "string") {
+    return { message: error };
+  }
+
+  const nested = error.error ?? error;
+  return {
+    message:
+      nested.message ||
+      error.message ||
+      "Resend request failed",
+    name: nested.name || error.name,
+    statusCode: nested.statusCode ?? error.statusCode ?? null,
+  };
+}
+
+function buildVerificationMailContent(otp, recipientEmail, nameValue) {
+  const subject = "Email for Verification";
+  const text = `Hello ${nameValue}
+    You registered an account on PiperChat, Here is your otp for verification - ${otp}
+    Kind Regards, Sunil Kumar`;
+
+  return { subject, text, to: recipientEmail };
+}
+
+function createSmtpTransporter() {
   const smtpPort = process.env.SMTP_PORT
     ? Number(process.env.SMTP_PORT)
     : undefined;
   const smtpUser = process.env.SMTP_USER || emailUser;
   const smtpPass = process.env.SMTP_PASS || process.env.MAIL_PASS;
 
-  if (smtpHost && smtpUser && smtpPass) {
-    return nodemailer.createTransport({
-      host: smtpHost,
-      port: smtpPort || 587,
-      secure: Boolean(process.env.SMTP_SECURE) || (smtpPort === 465),
-      auth: { user: smtpUser, pass: smtpPass },
-    });
-  }
-
-  if (emailUser && process.env.MAIL_PASS) {
-    return nodemailer.createTransport({
-      service: "gmail",
-      auth: { user: emailUser, pass: process.env.MAIL_PASS },
-    });
-  }
-
-  if (
-    emailUser &&
-    process.env.OAUTH_CLIENTID &&
-    process.env.OAUTH_CLIENT_SECRET &&
-    process.env.OAUTH_REFRESH_TOKEN
-  ) {
-    return nodemailer.createTransport({
-      service: "gmail",
-      auth: {
-        type: "OAuth2",
-        user: emailUser,
-        clientId: process.env.OAUTH_CLIENTID,
-        clientSecret: process.env.OAUTH_CLIENT_SECRET,
-        refreshToken: process.env.OAUTH_REFRESH_TOKEN,
-      },
-    });
-  }
-
-  return null;
+  return nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: smtpPort || 587,
+    secure: Boolean(process.env.SMTP_SECURE) || smtpPort === 465,
+    auth: { user: smtpUser, pass: smtpPass },
+  });
 }
 
-async function sendMail(otp, mailValue, nameValue) {
-  const transporter = createTransporter();
+function createGmailPasswordTransporter() {
+  return nodemailer.createTransport({
+    service: "gmail",
+    auth: { user: emailUser, pass: process.env.MAIL_PASS },
+  });
+}
 
+function createGmailOAuthTransporter() {
+  return nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      type: "OAuth2",
+      user: emailUser,
+      clientId: process.env.OAUTH_CLIENTID,
+      clientSecret: process.env.OAUTH_CLIENT_SECRET,
+      refreshToken: process.env.OAUTH_REFRESH_TOKEN,
+    },
+  });
+}
+
+/**
+ * @param {Exclude<EmailProvider, "console" | "resend">} provider
+ */
+function createNodemailerTransporter(provider) {
+  switch (provider) {
+    case "smtp":
+      return createSmtpTransporter();
+    case "gmail":
+      return createGmailPasswordTransporter();
+    case "gmail-oauth":
+      return createGmailOAuthTransporter();
+    default:
+      return null;
+  }
+}
+
+function logResendError(error) {
+  console.error("[email][resend] Delivery failed:", {
+    message: error?.message,
+    name: error?.name,
+    statusCode: error?.statusCode,
+  });
+}
+
+function logNodemailerError(provider, error) {
+  console.error(`[email][${provider}] Delivery failed:`, error?.message || error);
+}
+
+async function sendViaConsole(content) {
+  console.info("[email][console] Verification email (not sent):", {
+    to: content.to,
+    subject: content.subject,
+    body: content.text,
+  });
+  return { ok: true, provider: "console" };
+}
+
+async function sendViaResend(content) {
+  const client = getResendClient();
+  if (!client) {
+    return { ok: false, reason: "mail_not_configured", provider: "resend" };
+  }
+
+  const from = getFromAddress();
+
+  try {
+    const { data, error } = await withTimeout(
+      client.emails.send({
+        from,
+        to: [content.to],
+        subject: content.subject,
+        text: content.text,
+      }),
+      RESEND_SEND_TIMEOUT_MS,
+      "Resend send"
+    );
+
+    if (error) {
+      const normalized = normalizeResendError(error);
+      logResendError(normalized);
+      return {
+        ok: false,
+        reason: "send_failed",
+        provider: "resend",
+        error: normalized,
+      };
+    }
+
+    return { ok: true, provider: "resend", info: data };
+  } catch (error) {
+    const normalized = normalizeResendError(error);
+    logResendError(normalized);
+    return {
+      ok: false,
+      reason: "send_failed",
+      provider: "resend",
+      error: normalized,
+    };
+  }
+}
+
+async function sendViaNodemailer(content, provider) {
+  const transporter = createNodemailerTransporter(provider);
   if (!transporter) {
-    console.warn("[email] Mail not configured; unable to send verification email.");
-    return { ok: false, reason: "mail_not_configured" };
+    return { ok: false, reason: "mail_not_configured", provider };
   }
 
   const mailOptions = {
-    from: emailUser,
-    to: mailValue,
-    subject: "Email for Verification",
-    text: `Hello ${nameValue}
-    You registered an account on PiperChat, Here is your otp for verification - ${otp}
-    Kind Regards, Sunil Kumar`,
+    from: emailUser || getFromAddress(),
+    to: content.to,
+    subject: content.subject,
+    text: content.text,
   };
 
   try {
-    const info = await transporter.sendMail(mailOptions);
-    return { ok: true, info };
+    const info = await withTimeout(
+      transporter.sendMail(mailOptions),
+      RESEND_SEND_TIMEOUT_MS,
+      `${provider} send`
+    );
+    return { ok: true, provider, info };
   } catch (error) {
-    console.error("Error sending email:", error);
-    return { ok: false, reason: "send_failed" };
+    logNodemailerError(provider, error);
+    return {
+      ok: false,
+      reason: "send_failed",
+      provider,
+      error: { message: error?.message || String(error) },
+    };
+  }
+}
+
+async function sendMail(otp, mailValue, nameValue) {
+  const provider = resolveEmailProvider();
+  const content = buildVerificationMailContent(otp, mailValue, nameValue);
+
+  if (!provider) {
+    console.warn(
+      "[email] Mail not configured; unable to send verification email."
+    );
+    return { ok: false, reason: "mail_not_configured" };
+  }
+
+  switch (provider) {
+    case "console":
+      return sendViaConsole(content);
+    case "resend":
+      return sendViaResend(content);
+    case "smtp":
+    case "gmail":
+    case "gmail-oauth":
+      return sendViaNodemailer(content, provider);
+    default:
+      return { ok: false, reason: "mail_not_configured" };
   }
 }
 

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -51,10 +51,30 @@ export function signup(email, username, password, dob) {
   })();
 }
 
+function dispatchVerificationEmail(otp, email, username, context) {
+  sendMail(otp, email, username)
+    .then((mailResult) => {
+      if (!mailResult.ok) {
+        console.warn(`[auth/${context}] Verification email not sent:`, {
+          email,
+          reason: mailResult.reason,
+          provider: mailResult.provider,
+          error: mailResult.error?.message,
+        });
+      }
+    })
+    .catch((err) => {
+      console.error(
+        `[auth/${context}] sendMail error:`,
+        err?.message || err
+      );
+    });
+}
+
 export async function updatingCreds(accountCreds, otp, email, username) {
   await User.updateOne({ email }, accountCreds);
-  const mailResult = await sendMail(otp, email, username);
-  return { message: "updated", status: 201, mailResult };
+  dispatchVerificationEmail(otp, email, username, "updatingCreds");
+  return { message: "updated", status: 201, mailResult: { ok: null } };
 }
 
 export function generateTag(countValue) {


### PR DESCRIPTION
## Summary

This PR integrates Resend as the preferred email provider for OTP/verification delivery while preserving backward compatibility with the existing Nodemailer-based SMTP/Gmail flow.

The goal was to improve:

* contributor onboarding
* local development experience
* email delivery reliability
* auth/email flow resilience

without breaking the current signup, verification, or signin behavior.

---

## What Changed

### Resend Integration

* Added support for:

  * `RESEND_API_KEY`
  * `RESEND_FROM_EMAIL`
* Implemented Resend as the primary provider when configured.

### Provider Abstraction Improvements

Refactored email provider resolution into a cleaner flow:

```text id="49q2xz"
console → Resend → SMTP → Gmail → Gmail OAuth
```

* Preserved all existing fallback behavior.
* Existing SMTP/Gmail setups continue working.

### Resilient Email Delivery

* OTP email sending is now decoupled from the main signup response flow.
* Signup no longer blocks on third-party email provider latency/failures.
* Added timeout handling for email delivery operations.
* Added clearer provider-specific logging and structured failure responses.

### Auth Flow Stability

Preserved compatibility with:

* signup
* OTP verification
* resend OTP
* signin

### Developer Experience Improvements

* Added sandbox-safe Resend defaults for local testing.
* Preserved `MAIL_TRANSPORT=console` mode for automated/local tests.
* Improved graceful handling when mail providers are not configured.

### Frontend/API Hardening

* Improved fetch timeout handling
* safer JSON parsing
* clearer API error responses
* consistent backend JSON responses for auth routes

---

## Local Verification

Verified locally with Resend enabled:

* provider resolution → `resend`
* successful OTP email delivery
* signup flow
* OTP verification flow
* resend OTP flow
* signin flow
* fallback provider behavior
* `npm run test:auth`

Resend sandbox delivery was tested successfully using the allowed sandbox recipient.

---

## Notes

* Existing SMTP/Gmail fallback behavior remains intact.
* `MAIL_TRANSPORT=console` mode continues to work for local/CI testing.
* Resend sandbox mode only allows delivery to verified/test recipient emails unless a domain is configured.

Fixes #44 