### PR TITLE
feat: add emoji reactions to chat messages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -69,7 +69,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2192,7 +2191,8 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
@@ -2247,7 +2247,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2569,7 +2568,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2737,7 +2735,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3238,7 +3237,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5246,7 +5244,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5259,7 +5256,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -5288,7 +5284,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
       "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -5439,7 +5434,6 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -6286,7 +6280,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/components/chat/messages/ValidChat.jsx
+++ b/frontend/src/components/chat/messages/ValidChat.jsx
@@ -30,6 +30,10 @@ function ValidChat() {
   const [editingContent, setEditingContent] = useState("");
   const [showEmojiPicker, setShowEmojiPicker] = useState(null);
   const emojiPickerRef = useRef(null);
+
+  useEffect(() => {
+    setShowEmojiPicker(null);
+  }, [channel_id]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -154,7 +158,7 @@ function ValidChat() {
   };
 
   const toggleReaction = async (message, emoji) => {
-    const res = await fetch(`${url}/toggle_reaction`, {
+    const res = await fetch(`${url}/chat/toggle_reaction`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -390,7 +394,7 @@ function ValidChat() {
                     </div>
                   </div>
 
-                  {(elem.reactions && elem.reactions.length > 0) && (
+                  {(Array.isArray(elem.reactions) && elem.reactions.length > 0) && (
                     <div className="mt-1 flex flex-wrap gap-1">
                       {elem.reactions.map((r) => (
                         <button

--- a/frontend/src/components/chat/messages/ValidChat.jsx
+++ b/frontend/src/components/chat/messages/ValidChat.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Hash, Pencil, Trash2, Save, SendHorizontal, Loader2, AlertCircle } from "lucide-react";
 import socket from "../../socket/Socket";
@@ -28,6 +28,8 @@ function ValidChat() {
   const [all_messages, setall_messages] = useState([]);
   const [editingTimestamp, setEditingTimestamp] = useState(null);
   const [editingContent, setEditingContent] = useState("");
+  const [showEmojiPicker, setShowEmojiPicker] = useState(null);
+  const emojiPickerRef = useRef(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -151,6 +153,24 @@ function ValidChat() {
     }
   };
 
+  const toggleReaction = async (message, emoji) => {
+    const res = await fetch(`${url}/toggle_reaction`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-auth-token": localStorage.getItem("token"),
+      },
+      body: JSON.stringify({
+        server_id,
+        channel_id,
+        timestamp: message.timestamp,
+        emoji,
+      }),
+    });
+    await res.json();
+    setShowEmojiPicker(null);
+  };
+
   const deleteMessage = async (message) => {
     const res = await fetch(`${url}/chat/delete_server_message`, {
       method: "POST",
@@ -216,11 +236,23 @@ function ValidChat() {
       );
     };
     //earlier it was server_message_receive which was wrong
+    const handleReactionUpdated = ({ timestamp, reactions }) => {
+      setall_messages((currentMessages) =>
+        (currentMessages || []).map((entry) =>
+          String(entry.timestamp) === String(timestamp)
+            ? { ...entry, reactions }
+            : entry
+        )
+      );
+    };
+
+    socket.on("reaction_updated", handleReactionUpdated);
     socket.on("server_message_received", handleReceiveMessage);
     socket.on("server_message_updated", handleUpdatedMessage);
     socket.on("server_message_deleted", handleDeletedMessage);
 
     return () => {
+      socket.off("reaction_updated", handleReactionUpdated);
       socket.off("server_message_received", handleReceiveMessage);
       socket.off("server_message_updated", handleUpdatedMessage);
       socket.off("server_message_deleted", handleDeletedMessage);
@@ -304,8 +336,34 @@ function ValidChat() {
                     <div className="text-[10px] leading-none text-white/35">
                       {timestamp}
                     </div>
+                    <div className="ml-auto flex items-center gap-1 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100">
+                      <div className="relative">
+                        <button
+                          type="button"
+                          className="rounded-lg border border-white/10 bg-white/5 p-1.5 text-white/60 transition hover:bg-white/10 hover:text-white"
+                          onClick={() => setShowEmojiPicker(showEmojiPicker === elem.timestamp ? null : elem.timestamp)}
+                          title="React"
+                          aria-label="React"
+                        >
+                          😊
+                        </button>
+                        {showEmojiPicker === elem.timestamp && (
+                          <div ref={emojiPickerRef} className="absolute bottom-full right-0 z-50 mb-1 flex gap-1 rounded-xl border border-white/10 bg-[#1e1f22] p-2 shadow-xl">
+                            {["👍","❤️","😂","😮","😢","🔥","🎉","👀"].map((emoji) => (
+                              <button
+                                key={emoji}
+                                type="button"
+                                className="rounded-lg p-1 text-lg transition hover:bg-white/10"
+                                onClick={() => toggleReaction(elem, emoji)}
+                              >
+                                {emoji}
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                      </div>
                     {mine ? (
-                      <div className="ml-auto flex items-center gap-1 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100">
+                      <div className="flex items-center gap-1">
                         <button
                           type="button"
                           className="rounded-lg border border-white/10 bg-white/5 p-1.5 text-white/60 transition hover:bg-white/10 hover:text-white"
@@ -329,8 +387,27 @@ function ValidChat() {
                         </button>
                       </div>
                     ) : null}
+                    </div>
                   </div>
 
+                  {(elem.reactions && elem.reactions.length > 0) && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {elem.reactions.map((r) => (
+                        <button
+                          key={r.emoji}
+                          type="button"
+                          onClick={() => toggleReaction(elem, r.emoji)}
+                          className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition ${
+                            r.users.includes(id)
+                              ? "border-brand-300/50 bg-brand-300/20 text-brand-300"
+                              : "border-white/10 bg-white/5 text-white/70 hover:bg-white/10"
+                          }`}
+                        >
+                          {r.emoji} {r.users.length}
+                        </button>
+                      ))}
+                    </div>
+                  )}
                   {isEditing ? (
                     <div className="mt-2 flex items-center gap-2">
                       <Input

--- a/frontend/src/components/directMessages/DirectMessage.jsx
+++ b/frontend/src/components/directMessages/DirectMessage.jsx
@@ -16,6 +16,7 @@ function DirectMessage() {
   const [input, setInput] = useState("");
   const [editingTimestamp, setEditingTimestamp] = useState(null);
   const [editingContent, setEditingContent] = useState("");
+  const [showEmojiPicker, setShowEmojiPicker] = useState(null);
   const [friendIsTyping, setFriendIsTyping] = useState(false);
   const typingTimeoutRef = useRef(null);
   const isTypingRef = useRef(false);
@@ -129,12 +130,25 @@ function DirectMessage() {
       }
     };
 
+    const handleDmReactionUpdated = ({ timestamp, reactions, friend_id: fid }) => {
+      if (!activeFriend || fid !== activeFriend.id) return;
+      setMessages((currentMessages) =>
+        (currentMessages || []).map((entry) =>
+          String(entry.timestamp) === String(timestamp)
+            ? { ...entry, reactions }
+            : entry
+        )
+      );
+    };
+
+    socket.on("dm_reaction_updated", handleDmReactionUpdated);
     socket.on("direct_message_received", handleIncomingMessage);
     socket.on("direct_message_updated", handleUpdatedMessage);
     socket.on("direct_message_deleted", handleDeletedMessage);
     socket.on("dm_typing", handleTyping);
     socket.on("dm_stop_typing", handleStopTyping);
     return () => {
+      socket.off("dm_reaction_updated", handleDmReactionUpdated);
       socket.off("direct_message_received", handleIncomingMessage);
       socket.off("direct_message_updated", handleUpdatedMessage);
       socket.off("direct_message_deleted", handleDeletedMessage);
@@ -216,6 +230,23 @@ function DirectMessage() {
       setEditingTimestamp(null);
       setEditingContent("");
     }
+  };
+
+  const toggleDmReaction = async (message, emoji) => {
+    const res = await fetch(`${url}/direct-messages/toggle_dm_reaction`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-auth-token": localStorage.getItem("token"),
+      },
+      body: JSON.stringify({
+        friend_id: activeFriend.id,
+        timestamp: message.timestamp,
+        emoji,
+      }),
+    });
+    await res.json();
+    setShowEmojiPicker(null);
   };
 
   const deleteMessage = async (message) => {
@@ -332,6 +363,50 @@ function DirectMessage() {
                         {message.content}
                       </div>
 
+                      {(Array.isArray(message.reactions) && message.reactions.length > 0) && (
+                        <div className="mt-1 flex flex-wrap gap-1">
+                          {message.reactions.map((r) => (
+                            <button
+                              key={r.emoji}
+                              type="button"
+                              onClick={() => toggleDmReaction(message, r.emoji)}
+                              className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition ${
+                                r.users.includes(currentUser.id)
+                                  ? "border-brand-300/50 bg-brand-300/20 text-brand-300"
+                                  : "border-white/10 bg-white/5 text-white/70 hover:bg-white/10"
+                              }`}
+                            >
+                              {r.emoji} {r.users.length}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                      <div className="relative">
+                        <div className={["absolute -top-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100", mine ? "right-10" : "left-0"].join(" ")}>
+                          <button
+                            type="button"
+                            className="rounded-xl border border-white/10 bg-zinc-950/70 p-1.5 text-white/65 shadow-soft backdrop-blur transition hover:bg-zinc-950/85 hover:text-white"
+                            onClick={() => setShowEmojiPicker(showEmojiPicker === message.timestamp ? null : message.timestamp)}
+                            title="React"
+                          >
+                            😊
+                          </button>
+                        </div>
+                        {showEmojiPicker === message.timestamp && (
+                          <div className="absolute bottom-full left-0 z-50 mb-1 flex gap-1 rounded-xl border border-white/10 bg-[#1e1f22] p-2 shadow-xl">
+                            {["👍","❤️","😂","😮","😢","🔥","🎉","👀"].map((emoji) => (
+                              <button
+                                key={emoji}
+                                type="button"
+                                className="rounded-lg p-1 text-lg transition hover:bg-white/10"
+                                onClick={() => toggleDmReaction(message, emoji)}
+                              >
+                                {emoji}
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                      </div>
                       {mine ? (
                         <div
                           className={[

--- a/server/src/models/Chat.js
+++ b/server/src/models/Chat.js
@@ -1,5 +1,4 @@
 import mongoose from "mongoose";
-
 const chatSchema = new mongoose.Schema({
   server_id: String,
   channels: [
@@ -14,10 +13,15 @@ const chatSchema = new mongoose.Schema({
           sender_pic: String,
           sender_tag: String,
           timestamp: String,
+          reactions: [
+            {
+              emoji: String,
+              users: [String],
+            },
+          ],
         },
       ],
     },
   ],
 });
-
 export default mongoose.model("discord_chats", chatSchema);

--- a/server/src/models/DirectMessageThread.js
+++ b/server/src/models/DirectMessageThread.js
@@ -1,5 +1,4 @@
 import mongoose from "mongoose";
-
 const directMessageThreadSchema = new mongoose.Schema({
   participants: [String],
   messages: [
@@ -10,8 +9,13 @@ const directMessageThreadSchema = new mongoose.Schema({
       sender_pic: String,
       content: String,
       timestamp: Number,
+      reactions: [
+        {
+          emoji: String,
+          users: [String],
+        },
+      ],
     },
   ],
 });
-
 export default mongoose.model("direct_message_threads", directMessageThreadSchema);

--- a/server/src/routes/chat.js
+++ b/server/src/routes/chat.js
@@ -296,4 +296,57 @@ router.post("/delete_server_message", async (req, res) => {
   }
 });
 
+router.post("/toggle_reaction", async (req, res) => {
+  const { server_id, channel_id, timestamp, emoji } = req.body;
+  const user = getAuthorizedUser(req, res);
+  if (!user) return;
+  const userId = user.id;
+
+  try {
+    const chatDoc = await Chat.findOne({
+      server_id,
+      "channels.channel_id": channel_id,
+    });
+    if (!chatDoc) return res.status(404).json({ status: 404 });
+
+    const channel = chatDoc.channels.find((c) => c.channel_id === channel_id);
+    const message = channel?.chat_details.find(
+      (m) => String(m.timestamp) === String(timestamp)
+    );
+    if (!message) return res.status(404).json({ status: 404 });
+
+    if (!message.reactions) message.reactions = [];
+    let reaction = message.reactions.find((r) => r.emoji === emoji);
+
+    if (reaction) {
+      if (reaction.users.includes(userId)) {
+        reaction.users = reaction.users.filter((u) => u !== userId);
+        if (reaction.users.length === 0) {
+          message.reactions = message.reactions.filter((r) => r.emoji !== emoji);
+        }
+      } else {
+        reaction.users.push(userId);
+      }
+    } else {
+      message.reactions.push({ emoji, users: [userId] });
+    }
+
+    chatDoc.markModified("channels");
+    await chatDoc.save();
+    await cache.del(`chat:${server_id}:${channel_id}`);
+
+    const io = getIO();
+    if (io) {
+      io.to(`channel:${channel_id}`).emit("reaction_updated", {
+        timestamp,
+        reactions: message.reactions,
+      });
+    }
+
+    res.json({ status: 200, reactions: message.reactions });
+  } catch (err) {
+    res.status(500).json({ status: 500 });
+  }
+});
+
 export default router;

--- a/server/src/routes/directMessages.js
+++ b/server/src/routes/directMessages.js
@@ -248,4 +248,59 @@ router.post("/delete_direct_message", async (req, res) => {
   return res.status(200).json({ status: 200, message: "Message deleted" });
 });
 
+router.post("/toggle_dm_reaction", async (req, res) => {
+  const user = getAuthorizedUser(req, res);
+  if (!user) return;
+
+  const { friend_id, timestamp, emoji } = req.body;
+  if (!friend_id || !timestamp || !emoji) {
+    return res.status(400).json({ status: 400, message: "Invalid input" });
+  }
+
+  const participants = getThreadParticipants(user.id, friend_id);
+  const thread = await DirectMessageThread.findOne({ participants });
+  if (!thread) return res.status(404).json({ status: 404 });
+
+  const message = thread.messages.find(
+    (m) => String(m.timestamp) === String(timestamp)
+  );
+  if (!message) return res.status(404).json({ status: 404 });
+
+  if (!message.reactions) message.reactions = [];
+  let reaction = message.reactions.find((r) => r.emoji === emoji);
+
+  if (reaction) {
+    if (reaction.users.includes(user.id)) {
+      reaction.users = reaction.users.filter((u) => u !== user.id);
+      if (reaction.users.length === 0) {
+        message.reactions = message.reactions.filter((r) => r.emoji !== emoji);
+      }
+    } else {
+      reaction.users.push(user.id);
+    }
+  } else {
+    message.reactions.push({ emoji, users: [user.id] });
+  }
+
+  thread.markModified("messages");
+  await thread.save();
+  await cache.del(`dm:${participants[0]}:${participants[1]}`);
+
+  const io = getIO();
+  if (io) {
+    io.to(friend_id).emit("dm_reaction_updated", {
+      timestamp,
+      reactions: message.reactions,
+      friend_id: user.id,
+    });
+    io.to(user.id).emit("dm_reaction_updated", {
+      timestamp,
+      reactions: message.reactions,
+      friend_id,
+    });
+  }
+
+  res.json({ status: 200, reactions: message.reactions });
+});
+
 export default router;


### PR DESCRIPTION
Closes #124

## What this PR does
Adds emoji reactions to chat messages in PiperChat, a core Discord feature that was missing. Users can hover over any message, click the 😊 button, and pick from 8 emojis. Reactions appear below messages with counts and sync in real time via Socket.IO.

## Changes Made

### Backend (server/)
- Added `reactions` array field to Chat.js message schema
- Added `POST /toggle_reaction` endpoint in routes/chat.js
- Emits `reaction_updated` Socket.IO event to all clients in the channel

### Frontend (frontend/)
- Added emoji picker button (😊) on message hover
- Added emoji picker popup with 8 emojis: 👍 ❤️ 😂 😮 😢 🔥 🎉 👀
- Added reaction bar below messages showing emoji + count
- Your own reactions are highlighted in purple
- Clicking an existing reaction toggles it off
- Added Socket.IO listener for real-time reaction updates

## Mockup Screenshot:
<img width="1440" height="462" alt="image" src="https://github.com/user-attachments/assets/85d7a9c1-775a-4db7-834e-8b415a165f90" />



## How it works
1. Hover over any message → 😊 button appears
2. Click 😊 → emoji picker pops up
3. Select emoji → reaction appears below message
4. Click reaction again → removes your reaction
5. All reactions sync in real time for all users in the channel