### PR TITLE
fix: remove extra closing parenthesis in rgba() color value

### DIFF
--- a/frontend/src/components/auth/AuthShell.jsx
+++ b/frontend/src/components/auth/AuthShell.jsx
@@ -148,7 +148,7 @@ export default function AuthShell({ children, mode }) {
                   <div className="text-xs font-bold" style={{ color: "rgba(255,255,255,0.85)" }}>
                     {item.label}
                   </div>
-                  <div className="text-xs mt-0.5" style={{ color: "rgba(255,255,255,0.65))" }}>
+                  <div className="text-xs mt-0.5" style={{ color: "rgba(255,255,255,0.65)" }}>
                     {item.sub}
                   </div>
                 </motion.div>


### PR DESCRIPTION
## Description

Fixes an invalid CSS `rgba()` value in AuthShell.jsx that had an extra closing parenthesis, causing the style to be silently ignored.

## Changes
- Removed extra `)` from `rgba(255,255,255,0.65))` → `rgba(255,255,255,0.65)`

Closes #151