### PR TITLE
Enable message pinning with unpin support in channel view

### DIFF
--- a/frontend/src/components/chat/header/TopnavChat.jsx
+++ b/frontend/src/components/chat/header/TopnavChat.jsx
@@ -5,16 +5,114 @@ import {
   LogOut,
   Menu,
   Pin,
+  Loader2,
   Search,
   UsersRound,
 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
 import { logout } from "../../../lib/logout";
+import socket from "../../socket/Socket";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "../../ui/dialog";
+import { API_BASE_URL } from "../../../config";
 
 
 function TopnavChat({ onToggleSidebar }) {
+  const [pinnedMessagesOpen, setPinnedMessagesOpen] = useState(false);
+  const [channelMessages, setChannelMessages] = useState([]);
+  const [loadingPinnedMessages, setLoadingPinnedMessages] = useState(false);
 
-  const channel_name = useSelector(state=>state.currentPage.page_name)
+  const { server_id } = useParams();
+  const channel_id = useSelector((state) => state.currentPage.page_id);
+  const channel_name = useSelector((state) => state.currentPage.page_name);
+  const pinnedMessages = channelMessages.filter((message) => message.is_pinned);
+
+  const fetchChannelMessages = useCallback(async () => {
+    const res = await fetch(`${API_BASE_URL}/chat/get_messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-auth-token": localStorage.getItem("token"),
+      },
+      body: JSON.stringify({ server_id, channel_id }),
+    });
+
+    const data = await res.json();
+    setChannelMessages(data.chats || []);
+  }, [channel_id, server_id]);
+
+  useEffect(() => {
+    if (!pinnedMessagesOpen || !server_id || !channel_id) {
+      return;
+    }
+
+    let isActive = true;
+
+    const refreshPinnedMessages = async () => {
+      setLoadingPinnedMessages(true);
+      try {
+        if (!isActive) {
+          return;
+        }
+
+        await fetchChannelMessages();
+      } catch {
+        if (isActive) {
+          setChannelMessages([]);
+        }
+      } finally {
+        if (isActive) {
+          setLoadingPinnedMessages(false);
+        }
+      }
+    };
+
+    const handlePinnedUpdate = (messageData) => {
+      if (
+        String(messageData?.server_id) !== String(server_id) ||
+        String(messageData?.channel_id) !== String(channel_id)
+      ) {
+        return;
+      }
+
+      refreshPinnedMessages();
+    };
+
+    refreshPinnedMessages();
+    socket.on("server_message_pin_updated", handlePinnedUpdate);
+
+    return () => {
+      isActive = false;
+      socket.off("server_message_pin_updated", handlePinnedUpdate);
+    };
+  }, [pinnedMessagesOpen, channel_id, fetchChannelMessages, server_id]);
+
+  const handleTogglePin = async (message) => {
+    const res = await fetch(`${API_BASE_URL}/chat/toggle_server_message_pin`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-auth-token": localStorage.getItem("token"),
+      },
+      body: JSON.stringify({
+        server_id,
+        channel_id,
+        timestamp: message.timestamp,
+        sender_id: message.sender_id,
+      }),
+    });
+
+    if (res.ok) {
+      await fetchChannelMessages();
+    }
+  };
+
   return (
     <>
       <div className="flex h-full items-center justify-between gap-3 border-b border-white/10 bg-black/30 px-3 sm:px-4">
@@ -38,19 +136,20 @@ function TopnavChat({ onToggleSidebar }) {
         <div className="hidden flex-1 items-center justify-end gap-2 lg:flex">
           <button
             type="button"
+            onClick={() => setPinnedMessagesOpen(true)}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-white/70 transition hover:bg-white/10 hover:text-white"
+            title="Pin messages"
+            aria-label="Pin messages"
+          >
+            <Pin className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
             className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-white/70 transition hover:bg-white/10 hover:text-white"
             title="Notifications"
             aria-label="Notifications"
           >
             <Bell className="h-5 w-5" />
-          </button>
-          <button
-            type="button"
-            className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-white/70 transition hover:bg-white/10 hover:text-white"
-            title="Pinned messages"
-            aria-label="Pinned messages"
-          >
-            <Pin className="h-5 w-5" />
           </button>
           <button
             type="button"
@@ -100,6 +199,66 @@ function TopnavChat({ onToggleSidebar }) {
           </button>
         </div>
       </div>
+
+      <Dialog open={pinnedMessagesOpen} onOpenChange={setPinnedMessagesOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogTitle>Pinned messages</DialogTitle>
+          <DialogDescription className="mt-2">
+            Manage pinned messages in #{channel_name || "channel"}.
+          </DialogDescription>
+
+          <div className="mt-5 max-h-[50vh] space-y-3 overflow-y-auto pr-1">
+            {loadingPinnedMessages ? (
+              <div className="flex items-center justify-center py-10 text-white/60">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Loading messages...
+              </div>
+            ) : pinnedMessages.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-white/10 bg-white/5 px-4 py-8 text-center text-sm text-white/55">
+                No pinned messages yet.
+              </div>
+            ) : (
+              pinnedMessages.map((message) => {
+                const date = new Date(Number(message.timestamp));
+                const formattedTime = `${date.toDateString()}, ${String(
+                  date.getHours(),
+                ).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+
+                return (
+                  <div
+                    key={`${message.timestamp}-${message.sender_id}`}
+                    className="rounded-2xl border border-white/10 bg-white/5 p-4"
+                  >
+                    <div className="flex items-center gap-2 text-sm font-semibold text-white">
+                      <Pin className="h-4 w-4 text-brand-300" />
+                      <span>{message.sender_name}</span>
+                      <span className="text-xs font-normal text-white/40">{formattedTime}</span>
+                      {message.is_pinned ? (
+                        <span className="rounded-full border border-brand-300/25 bg-brand-300/10 px-2 py-0.5 text-[10px] font-semibold text-brand-200">
+                          Pinned
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-white/80">
+                      {message.content}
+                    </div>
+                    <div className="mt-3 flex justify-end">
+                      <button
+                        type="button"
+                        onClick={() => handleTogglePin(message)}
+                        className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/75 transition hover:bg-white/10 hover:text-white"
+                      >
+                        <Pin className="h-4 w-4" />
+                        Unpin
+                      </button>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }

--- a/frontend/src/components/chat/messages/ValidChat.jsx
+++ b/frontend/src/components/chat/messages/ValidChat.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Hash, Pencil, Trash2, Save, SendHorizontal, Loader2, AlertCircle } from "lucide-react";
+import { Hash, Pencil, Trash2, Save, SendHorizontal, Loader2, AlertCircle, Pin } from "lucide-react";
 import socket from "../../socket/Socket";
 import { useParams } from "react-router-dom";
 import { clear_channel_unread } from "../../../store/unreadSlice";
@@ -175,6 +175,34 @@ function ValidChat() {
     }
   };
 
+  const togglePinMessage = async (message) => {
+    const res = await fetch(`${url}/chat/toggle_server_message_pin`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-auth-token": localStorage.getItem("token"),
+      },
+      body: JSON.stringify({
+        server_id,
+        channel_id,
+        timestamp: message.timestamp,
+        sender_id: message.sender_id,
+      }),
+    });
+
+    const data = await res.json();
+    if (data.status === 200) {
+      setall_messages((currentMessages) =>
+        currentMessages.map((entry) =>
+          String(entry.timestamp) === String(message.timestamp) &&
+          String(entry.sender_id) === String(message.sender_id)
+            ? { ...entry, is_pinned: data.is_pinned }
+            : entry
+        )
+      );
+    }
+  };
+
   useEffect(() => {
     const handleReceiveMessage = (messageData) => {
       setall_messages((currentMessages) => {
@@ -215,15 +243,28 @@ function ValidChat() {
         )
       );
     };
+
+    const handlePinUpdatedMessage = (message_data) => {
+      setall_messages((currentMessages) =>
+        (currentMessages || []).map((entry) =>
+          String(entry.timestamp) === String(message_data.timestamp) &&
+          entry.sender_id === message_data.sender_id
+            ? { ...entry, is_pinned: message_data.is_pinned }
+            : entry
+        )
+      );
+    };
     //earlier it was server_message_receive which was wrong
     socket.on("server_message_received", handleReceiveMessage);
     socket.on("server_message_updated", handleUpdatedMessage);
     socket.on("server_message_deleted", handleDeletedMessage);
+    socket.on("server_message_pin_updated", handlePinUpdatedMessage);
 
     return () => {
       socket.off("server_message_received", handleReceiveMessage);
       socket.off("server_message_updated", handleUpdatedMessage);
       socket.off("server_message_deleted", handleDeletedMessage);
+      socket.off("server_message_pin_updated", handlePinUpdatedMessage);
     };
   }, []);
 
@@ -285,7 +326,7 @@ function ValidChat() {
             return (
               <div
                 key={`${elem.timestamp}-${elem.sender_id}`}
-                className="group flex gap-2 rounded-2xl px-1 py-1.5 transition hover:bg-white/5 sm:gap-3 sm:px-2 sm:py-2"
+                className={`group flex gap-2 rounded-2xl px-1 py-1.5 transition hover:bg-white/5 sm:gap-3 sm:px-2 sm:py-2 ${elem.is_pinned ? "border border-brand-300/20 bg-brand-300/5" : ""}`}
               >
                 <div className="relative mt-4 h-9 w-9 shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40 sm:mt-3 sm:h-10 sm:w-10">
                   <img
@@ -304,31 +345,48 @@ function ValidChat() {
                     <div className="text-[10px] leading-none text-white/35">
                       {timestamp}
                     </div>
-                    {mine ? (
-                      <div className="ml-auto flex items-center gap-1 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100">
-                        <button
-                          type="button"
-                          className="rounded-lg border border-white/10 bg-white/5 p-1.5 text-white/60 transition hover:bg-white/10 hover:text-white"
-                          onClick={() => {
-                            setEditingTimestamp(elem.timestamp);
-                            setEditingContent(elem.content);
-                          }}
-                          title="Edit"
-                          aria-label="Edit"
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </button>
-                        <button
-                          type="button"
-                          className="rounded-lg border border-white/10 bg-white/5 p-1.5 text-white/60 transition hover:bg-white/10 hover:text-white"
-                          onClick={() => deleteMessage(elem)}
-                          title="Delete"
-                          aria-label="Delete"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
+                    {elem.is_pinned ? (
+                      <div className="inline-flex items-center gap-1 rounded-full border border-brand-300/25 bg-brand-300/10 px-2 py-0.5 text-[10px] font-semibold text-brand-200">
+                        <Pin className="h-3 w-3" />
+                        Pinned
                       </div>
                     ) : null}
+                    <div className="ml-auto flex items-center gap-1">
+                      {mine ? (
+                        <div className="flex items-center gap-1 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100">
+                          <button
+                            type="button"
+                            className="rounded-lg border border-white/10 bg-white/5 p-1.5 text-white/60 transition hover:bg-white/10 hover:text-white"
+                            onClick={() => {
+                              setEditingTimestamp(elem.timestamp);
+                              setEditingContent(elem.content);
+                            }}
+                            title="Edit"
+                            aria-label="Edit"
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-lg border border-white/10 bg-white/5 p-1.5 text-white/60 transition hover:bg-white/10 hover:text-white"
+                            onClick={() => deleteMessage(elem)}
+                            title="Delete"
+                            aria-label="Delete"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      ) : null}
+                      <button
+                        type="button"
+                        className={`rounded-lg border border-white/10 bg-white/5 p-1.5 transition hover:bg-white/10 hover:text-white ${elem.is_pinned ? "text-brand-200" : "text-white/60"}`}
+                        onClick={() => togglePinMessage(elem)}
+                        title={elem.is_pinned ? "Unpin" : "Pin"}
+                        aria-label={elem.is_pinned ? "Unpin message" : "Pin message"}
+                      >
+                        <Pin className="h-4 w-4" />
+                      </button>
+                    </div>
                   </div>
 
                   {isEditing ? (

--- a/frontend/src/components/invite/Invite.jsx
+++ b/frontend/src/components/invite/Invite.jsx
@@ -19,12 +19,7 @@ function Invite() {
   const [invalid_invite_link, setinvalid_invite_link] = useState(null);
 
 const [already_member, setAlreadyMember] = useState(false);   // 403 from backend
-  const [accept_failed, setAcceptFailed] = useState(false);
-  const [accepting, setAccepting] = useState(false);
-
   const accept_invite = async () => {
-    setAccepting(true);
-    setAcceptFailed(false);
     setAlreadyMember(false);
 
     try {
@@ -45,13 +40,9 @@ const [already_member, setAlreadyMember] = useState(false);   // 403 from backen
         navigate("/channels/@me", { replace: true });
       } else if (data.status === 403) {
         setAlreadyMember(true);
-      } else {
-        setAcceptFailed(true);
       }
     } catch {
-      setAcceptFailed(true);
-    } finally {
-      setAccepting(false);
+      return;
     }
   };
 

--- a/frontend/src/components/invite/Invite.jsx
+++ b/frontend/src/components/invite/Invite.jsx
@@ -19,7 +19,12 @@ function Invite() {
   const [invalid_invite_link, setinvalid_invite_link] = useState(null);
 
 const [already_member, setAlreadyMember] = useState(false);   // 403 from backend
+  const [accept_failed, setAcceptFailed] = useState(false);
+  const [accepting, setAccepting] = useState(false);
+
   const accept_invite = async () => {
+    setAccepting(true);
+    setAcceptFailed(false);
     setAlreadyMember(false);
 
     try {
@@ -40,9 +45,13 @@ const [already_member, setAlreadyMember] = useState(false);   // 403 from backen
         navigate("/channels/@me", { replace: true });
       } else if (data.status === 403) {
         setAlreadyMember(true);
+      } else {
+        setAcceptFailed(true);
       }
     } catch {
-      return;
+      setAcceptFailed(true);
+    } finally {
+      setAccepting(false);
     }
   };
 

--- a/server/src/models/Chat.js
+++ b/server/src/models/Chat.js
@@ -14,6 +14,7 @@ const chatSchema = new mongoose.Schema({
           sender_pic: String,
           sender_tag: String,
           timestamp: String,
+          is_pinned: { type: Boolean, default: false },
         },
       ],
     },

--- a/server/src/routes/chat.js
+++ b/server/src/routes/chat.js
@@ -36,6 +36,21 @@ function getAuthorizedUser(req, res) {
   }
 }
 
+function normalizeChatMessages(chatDetails = []) {
+  return chatDetails.flatMap((entry) =>
+    Array.isArray(entry) ? entry.filter(Boolean) : [entry].filter(Boolean),
+  );
+}
+
+function findChatMessage(channel, timestamp, senderId) {
+  const messages = normalizeChatMessages(channel?.chat_details || []);
+  return messages.find(
+    (entry) =>
+      String(entry?.timestamp) === String(timestamp) &&
+      String(entry?.sender_id) === String(senderId),
+  );
+}
+
 router.post("/store_message", expressRateLimit("chat"), async (req, res) => {
   const {
     message,
@@ -56,6 +71,7 @@ router.post("/store_message", expressRateLimit("chat"), async (req, res) => {
     sender_pic: profile_pic,
     sender_tag: tag,
     timestamp,
+    is_pinned: false,
   };
 
   const response = await Chat.find({
@@ -121,7 +137,7 @@ router.post("/store_message", expressRateLimit("chat"), async (req, res) => {
   } else {
     const pushNewChat = {
       $push: {
-        "channels.$.chat_details": [chatMessage],
+        "channels.$.chat_details": chatMessage,
       },
     };
     try {
@@ -174,8 +190,9 @@ router.post("/get_messages", async (req, res) => {
       return res.json({ chats: [] });
     }
     const chats = response[0].channels[0].chat_details || [];
-    await cache.setJson(cacheKey, { chats });
-    return res.json({ chats });
+    const normalizedChats = normalizeChatMessages(chats);
+    await cache.setJson(cacheKey, { chats: normalizedChats });
+    return res.json({ chats: normalizedChats });
   } catch (error) {
     logger.error(`Error retrieving chats: ${error.message}`);
     res.status(500).json({ error: "Failed to retrieve chats." });
@@ -206,11 +223,7 @@ router.post("/edit_server_message", async (req, res) => {
     const channel = chatDoc.channels.find(
       (entry) => entry.channel_id === channel_id,
     );
-    const message = channel?.chat_details.find(
-      (entry) =>
-        String(entry.timestamp) === String(timestamp) &&
-        entry.sender_id === senderId,
-    );
+    const message = findChatMessage(channel, timestamp, senderId);
 
     if (!message) {
       return res
@@ -238,6 +251,65 @@ router.post("/edit_server_message", async (req, res) => {
   }
 });
 
+router.post("/toggle_server_message_pin", async (req, res) => {
+  const { server_id, channel_id, timestamp, sender_id } = req.body;
+  const user = getAuthorizedUser(req, res);
+  if (!user) {
+    return;
+  }
+
+  if (!server_id || !channel_id || !timestamp || !sender_id) {
+    return res.status(400).json({ status: 400, message: "Invalid input" });
+  }
+
+  try {
+    const chatDoc = await Chat.findOne({
+      server_id,
+      "channels.channel_id": channel_id,
+    });
+    if (!chatDoc) {
+      return res.status(404).json({ status: 404, message: "Chat not found" });
+    }
+
+    const channel = chatDoc.channels.find(
+      (entry) => entry.channel_id === channel_id,
+    );
+    const message = findChatMessage(channel, timestamp, sender_id);
+
+    if (!message) {
+      return res
+        .status(404)
+        .json({ status: 404, message: "Message not found" });
+    }
+
+    message.is_pinned = !message.is_pinned;
+    await chatDoc.save();
+    await cache.del(`chat:${server_id}:${channel_id}`);
+
+    const io = getIO();
+    if (io) {
+      io.to(`channel:${channel_id}`).emit("server_message_pin_updated", {
+        timestamp,
+        sender_id,
+        is_pinned: message.is_pinned,
+        channel_id,
+        server_id,
+      });
+    }
+
+    res.status(200).json({
+      status: 200,
+      message: message.is_pinned ? "Message pinned" : "Message unpinned",
+      is_pinned: message.is_pinned,
+    });
+  } catch (error) {
+    logger.error(`Error toggling pinned message: ${error.message}`);
+    res
+      .status(500)
+      .json({ status: 500, message: "Failed to toggle pinned message" });
+  }
+});
+
 router.post("/delete_server_message", async (req, res) => {
   const { server_id, channel_id, timestamp } = req.body;
   const user = getAuthorizedUser(req, res);
@@ -262,9 +334,10 @@ router.post("/delete_server_message", async (req, res) => {
     const channel = chatDoc.channels.find(
       (entry) => entry.channel_id === channel_id,
     );
-    const originalLength = channel?.chat_details.length || 0;
+    const channelMessages = normalizeChatMessages(channel?.chat_details || []);
+    const originalLength = channelMessages.length;
 
-    channel.chat_details = channel.chat_details.filter(
+    channel.chat_details = channelMessages.filter(
       (entry) =>
         !(
           String(entry.timestamp) === String(timestamp) &&


### PR DESCRIPTION
Description
This PR adds working message pin/unpin behavior to the channel view. The message row action now toggles pin state properly, and the pinned-messages panel shows only pinned messages with a direct Unpin action. I also cleaned up the header pin panel flow so it refreshes correctly and stays readable without unnecessary changes.

Validation:

Frontend lint passed for the touched header component
Frontend production build passed
Backend auth unit tests passed
Backend auth integration tests passed

Screenshots:
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/58939655-3bd0-488a-82c1-d29aafe66d34" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/c3c47aa5-d37e-49fc-87df-74a9c5ea2919" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Messages can now be pinned and unpinned with a dedicated button in message controls
* New "Pinned Messages" dialog displays all pinned messages within the current channel
* Pinned messages are visually highlighted with special styling and a badge indicator

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0rigin-c0de/PiperChat01/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->