### PR TITLE
Fix/auto scroll latest messages

### DIFF
--- a/frontend/src/components/chat/messages/ValidChat.jsx
+++ b/frontend/src/components/chat/messages/ValidChat.jsx
@@ -143,6 +143,10 @@ function ValidChat() {
     // eslint-disable-next-line
   }, [channel_id]);
 
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView();
+  }, [all_messages]);
+
   const get_messages = async () => {
     try {
       setIsLoading(true);
@@ -385,7 +389,7 @@ function ValidChat() {
 
   return (
     <div className="flex h-full min-w-0 flex-col">
-      <div className="flex-1 overflow-y-auto px-4 py-6">
+      <div className="flex-1 overflow-y-auto scrollbar-hide px-4 py-6">
         {isLoading ? (
           <div className="flex h-full items-center justify-center">
             <Loader2 className="h-8 w-8 animate-spin text-brand-300" />
@@ -543,6 +547,7 @@ function ValidChat() {
             );
           })}
         </div>
+        <div ref={messagesEndRef} />
         </>
         )}
       </div>

--- a/frontend/src/components/chat/messages/ValidChat.jsx
+++ b/frontend/src/components/chat/messages/ValidChat.jsx
@@ -33,6 +33,7 @@ function ValidChat() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [typingUsers, setTypingUsers] = useState({});
+  const messagesEndRef = useRef(null);
   const typingTimeoutRef = useRef(null);
   const typingUserTimeoutsRef = useRef({});
   const isTypingRef = useRef(false);

--- a/frontend/src/components/directMessages/DirectMessage.jsx
+++ b/frontend/src/components/directMessages/DirectMessage.jsx
@@ -19,6 +19,7 @@ function DirectMessage() {
   const [friendIsTyping, setFriendIsTyping] = useState(false);
   const typingTimeoutRef = useRef(null);
   const isTypingRef = useRef(false);
+  const messagesEndRef = useRef(null);
 
   const url = API_BASE_URL;
 
@@ -55,6 +56,10 @@ function DirectMessage() {
       });
     }
   }, [activeFriend, dispatch, loadMessages, url]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView();
+  }, [messages]);
 
   useEffect(() => {
     const handleIncomingMessage = (message) => {
@@ -267,7 +272,7 @@ function DirectMessage() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 py-4">
+      <div className="flex-1 overflow-y-auto scrollbar-hide px-4 py-4">
         <div className="space-y-3">
           {messages.map((message) => {
             const mine = message.sender_id === currentUser.id;
@@ -378,6 +383,7 @@ function DirectMessage() {
             );
           })}
         </div>
+        <div ref={messagesEndRef} />
       </div>
 
       {friendIsTyping && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -66,3 +66,11 @@
     transform: translateY(-6px);
   }
 }
+
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
## Fix: Chat auto-scroll to latest messages and hide scrollbar
## Issue : #108 
### Changes
- **ValidChat.jsx** — Added `useRef` + auto-scroll `useEffect` to scroll to latest messages when channel loads or new messages arrive. Added `scrollbar-hide` class.
- **DirectMessage.jsx** — Same auto-scroll fix for DM chat view. Added `scrollbar-hide` class.
- **index.css** — Added `.scrollbar-hide` utility class to hide scrollbars while keeping scroll functionality.
### Bug Fixed
The chat view was showing the oldest messages first at the top when opening a channel, requiring manual scroll-down. Now it auto-scrolls to the bottom to show the latest messages, matching the expected WhatsApp-like behavior.