### PR TITLE
feat(ui): add gradient scrollbar styling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -66,3 +66,38 @@
     transform: translateY(-6px);
   }
 }
+
+/* Chrome, Edge, Safari */
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: #0b0b12;
+}
+
+::-webkit-scrollbar-thumb {
+  background: linear-gradient(
+    to bottom,
+    #ff8a00,
+    #e52e71,
+    #7b61ff
+  );
+  border-radius: 999px;
+  border: 2px solid #0b0b12;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(
+    to bottom,
+    #ff9d2f,
+    #ff4f8b,
+    #9a84ff
+  );
+}
+
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #7b61ff #0b0b12;
+}


### PR DESCRIPTION
## Summary
Implemented a custom gradient scrollbar design to better match the application's dark neon UI aesthetic.

## Changes Made
- Added custom WebKit scrollbar styles
- Added gradient scrollbar thumb
- Added rounded scrollbar appearance
- Added hover transition effect
- Improved overall UI consistency

## Preview
- Dark scrollbar track
- Orange - Pink - Purple gradient thumb
- Smooth rounded styling

## Testing
- Tested on Chromium-based browsers
- Verified scrollbar visibility on dark backgrounds
- Confirmed no UI layout issues

## Screenshots
<img width="1919" height="1085" alt="Screenshot 2026-05-26 071016" src="https://github.com/user-attachments/assets/83ba07da-dadb-4847-9fef-029edc1aaddd" />

## Related Issue
Closes #176 