### PR TITLE
fix(validation): enforce chat and server input limits

### DIFF
--- a/frontend/src/components/chat/messages/ValidChat.jsx
+++ b/frontend/src/components/chat/messages/ValidChat.jsx
@@ -8,6 +8,7 @@ import { Input } from "../../ui/input";
 import { Button } from "../../ui/button";
 import { resolveProfilePic, handleImageError } from "../../../shared/imageFallbacks";
 import { API_BASE_URL } from "../../../config";
+import { MESSAGE_MAX_LENGTH } from "../../../lib/validationLimits";
 
 function ValidChat() {
   const dispatch = useDispatch();
@@ -32,6 +33,8 @@ function ValidChat() {
   const [editingContent, setEditingContent] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [messageError, setMessageError] = useState("");
+  const [editingError, setEditingError] = useState("");
   const [typingUsers, setTypingUsers] = useState({});
   const typingTimeoutRef = useRef(null);
   const typingUserTimeoutsRef = useRef({});
@@ -50,6 +53,7 @@ function ValidChat() {
   const handleMessageChange = (e) => {
     const nextMessage = e.target.value;
     setchat_message(nextMessage);
+    setMessageError("");
 
     if (!channel_id || !server_id || !id) {
       return;
@@ -83,8 +87,12 @@ function ValidChat() {
   }, [channel_id,server_id]);
 
   const sendNow = async () => {
-    if (!chat_message.trim()) return;
-    const message_to_send = chat_message;
+    const message_to_send = chat_message.trim();
+    if (!message_to_send) return;
+    if (chat_message.length > MESSAGE_MAX_LENGTH) {
+      setMessageError(`Message must be ${MESSAGE_MAX_LENGTH} characters or fewer.`);
+      return;
+    }
     const timestamp = Date.now();
     setchat_message("");
     stopTyping();
@@ -112,6 +120,7 @@ function ValidChat() {
     });
     const data = await res.json();
     if (data.status !== 200) {
+      setMessageError(data.message || "Message could not be sent.");
       setchat_message(chat_message);
     }
   };
@@ -173,6 +182,13 @@ function ValidChat() {
   };
 
   const editMessage = async (message) => {
+    const nextContent = editingContent.trim();
+    if (!nextContent) return;
+    if (editingContent.length > MESSAGE_MAX_LENGTH) {
+      setEditingError(`Message must be ${MESSAGE_MAX_LENGTH} characters or fewer.`);
+      return;
+    }
+
     const res = await fetch(`${url}/chat/edit_server_message`, {
       method: "POST",
       headers: {
@@ -192,12 +208,15 @@ function ValidChat() {
         currentMessages.map((entry) =>
           String(entry.timestamp) === String(message.timestamp) &&
           entry.sender_id === id
-            ? { ...entry, content: editingContent.trim() }
+            ? { ...entry, content: nextContent }
             : entry
         )
       );
       setEditingTimestamp(null);
       setEditingContent("");
+      setEditingError("");
+    } else {
+      setEditingError(data.message || "Message could not be updated.");
     }
   };
 
@@ -475,6 +494,7 @@ function ValidChat() {
                             onClick={() => {
                               setEditingTimestamp(elem.timestamp);
                               setEditingContent(elem.content);
+                              setEditingError("");
                             }}
                             title="Edit"
                             aria-label="Edit"
@@ -510,7 +530,11 @@ function ValidChat() {
                     <div className="mt-2 flex items-center gap-2">
                       <Input
                         value={editingContent}
-                        onChange={(e) => setEditingContent(e.target.value)}
+                        maxLength={MESSAGE_MAX_LENGTH}
+                        onChange={(e) => {
+                          setEditingContent(e.target.value);
+                          setEditingError("");
+                        }}
                         onKeyDown={(e) => {
                           if (e.key === "Enter" && editingContent.trim()) {
                             editMessage(elem);
@@ -532,6 +556,14 @@ function ValidChat() {
                         <Save className="h-4 w-4" />
                         Save
                       </Button>
+                      <div className="shrink-0 text-xs font-semibold text-white/35">
+                        {editingContent.length}/{MESSAGE_MAX_LENGTH}
+                      </div>
+                      {editingError ? (
+                        <div className="text-xs font-semibold text-red-300">
+                          {editingError}
+                        </div>
+                      ) : null}
                     </div>
                   ) : (
                     <div className="mt-0.5 whitespace-pre-wrap break-words text-sm leading-[1.45] text-white/85">
@@ -557,6 +589,7 @@ function ValidChat() {
         <div className="flex items-center gap-2">
           <Input
             value={chat_message}
+            maxLength={MESSAGE_MAX_LENGTH}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.preventDefault();
@@ -567,6 +600,9 @@ function ValidChat() {
             placeholder={`Message #${channel_name}`}
             className="flex-1"
           />
+          <div className="hidden w-20 text-right text-xs font-semibold text-white/35 sm:block">
+            {chat_message.length}/{MESSAGE_MAX_LENGTH}
+          </div>
           <Button
             type="button"
             onClick={sendNow}
@@ -576,6 +612,11 @@ function ValidChat() {
             <SendHorizontal className="h-4 w-4" />
           </Button>
         </div>
+        {messageError ? (
+          <div className="mt-2 text-xs font-semibold text-red-300">
+            {messageError}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/components/directMessages/DirectMessage.jsx
+++ b/frontend/src/components/directMessages/DirectMessage.jsx
@@ -7,6 +7,7 @@ import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Pencil, Trash2, Save, Send } from "lucide-react";
 import { API_BASE_URL } from "../../config";
+import { MESSAGE_MAX_LENGTH } from "../../lib/validationLimits";
 
 function DirectMessage() {
   const dispatch = useDispatch();
@@ -16,6 +17,8 @@ function DirectMessage() {
   const [input, setInput] = useState("");
   const [editingTimestamp, setEditingTimestamp] = useState(null);
   const [editingContent, setEditingContent] = useState("");
+  const [messageError, setMessageError] = useState("");
+  const [editingError, setEditingError] = useState("");
   const [friendIsTyping, setFriendIsTyping] = useState(false);
   const typingTimeoutRef = useRef(null);
   const isTypingRef = useRef(false);
@@ -146,6 +149,7 @@ function DirectMessage() {
 
   const handleInputChange = (e) => {
     setInput(e.target.value);
+    setMessageError("");
     if (!activeFriend) return;
     if (!isTypingRef.current) {
       isTypingRef.current = true;
@@ -160,6 +164,11 @@ function DirectMessage() {
 
   const sendMessage = async () => {
     if (!input.trim() || !activeFriend) return;
+
+    if (input.length > MESSAGE_MAX_LENGTH) {
+      setMessageError(`Message must be ${MESSAGE_MAX_LENGTH} characters or fewer.`);
+      return;
+    }
 
     const message = input.trim();
     setInput("");
@@ -180,6 +189,7 @@ function DirectMessage() {
     });
     const data = await res.json();
     if (data.status !== 200) {
+      setMessageError(data.message || "Message could not be sent.");
       setInput(message);
     }
   };
@@ -187,9 +197,17 @@ function DirectMessage() {
   const startEditing = (message) => {
     setEditingTimestamp(message.timestamp);
     setEditingContent(message.content);
+    setEditingError("");
   };
 
   const editMessage = async (message) => {
+    const nextContent = editingContent.trim();
+    if (!nextContent) return;
+    if (editingContent.length > MESSAGE_MAX_LENGTH) {
+      setEditingError(`Message must be ${MESSAGE_MAX_LENGTH} characters or fewer.`);
+      return;
+    }
+
     const res = await fetch(`${url}/direct-messages/edit_direct_message`, {
       method: "POST",
       headers: {
@@ -209,12 +227,15 @@ function DirectMessage() {
         currentMessages.map((entry) =>
           String(entry.timestamp) === String(message.timestamp) &&
           entry.sender_id === currentUser.id
-            ? { ...entry, content: editingContent.trim() }
+            ? { ...entry, content: nextContent }
             : entry
         )
       );
       setEditingTimestamp(null);
       setEditingContent("");
+      setEditingError("");
+    } else {
+      setEditingError(data.message || "Message could not be updated.");
     }
   };
 
@@ -302,7 +323,11 @@ function DirectMessage() {
                     <div className="mt-2 flex items-center gap-2">
                       <Input
                         value={editingContent}
-                        onChange={(e) => setEditingContent(e.target.value)}
+                        maxLength={MESSAGE_MAX_LENGTH}
+                        onChange={(e) => {
+                          setEditingContent(e.target.value);
+                          setEditingError("");
+                        }}
                         onKeyDown={(e) => {
                           if (e.key === "Enter" && editingContent.trim()) {
                             editMessage(message);
@@ -318,12 +343,21 @@ function DirectMessage() {
                         <Save className="h-4 w-4" />
                         Save
                       </Button>
+                      <div className="shrink-0 text-xs font-semibold text-white/35">
+                        {editingContent.length}/{MESSAGE_MAX_LENGTH}
+                      </div>
+                      {editingError ? (
+                        <div className="text-xs font-semibold text-red-300">
+                          {editingError}
+                        </div>
+                      ) : null}
                     </div>
                   ) : (
                     <div className="relative mt-2">
                       <div
                         className={[
                           "rounded-2xl border px-3 py-2 text-sm leading-relaxed",
+                          "break-words whitespace-pre-wrap",
                           mine
                             ? "border-brand-400/20 bg-brand-400/10 text-white"
                             : "border-white/10 bg-white/5 text-white/85",
@@ -395,14 +429,23 @@ function DirectMessage() {
         >
           <Input
             value={input}
+            maxLength={MESSAGE_MAX_LENGTH}
             onChange={handleInputChange}
             placeholder={`Message @${activeFriend.username}`}
             className="h-11"
           />
+          <div className="hidden w-20 text-right text-xs font-semibold text-white/35 sm:block">
+            {input.length}/{MESSAGE_MAX_LENGTH}
+          </div>
           <Button type="submit" disabled={!input.trim()} className="shrink-0">
             <Send className="h-4 w-4" />
           </Button>
         </form>
+        {messageError ? (
+          <div className="mt-2 text-xs font-semibold text-red-300">
+            {messageError}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/components/navbar/Navbar.jsx
+++ b/frontend/src/components/navbar/Navbar.jsx
@@ -19,6 +19,7 @@ import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { close_direct_message } from "../../store/directMessageSlice";
 import { API_BASE_URL } from "../../config";
+import { SERVER_NAME_MAX_LENGTH } from "../../lib/validationLimits";
 
 function Navbar({ new_req_recieved, user_cred, onNavigate }) {
   const dispatch = useDispatch();
@@ -35,6 +36,8 @@ function Navbar({ new_req_recieved, user_cred, onNavigate }) {
     setcurrent_modal(1);
     setsubmit_button({ create_button_state: false, back_button_state: false });
     setnew_server_image_preview(server_input);
+    setnew_server_image("");
+    setServerError("");
   };
   const handleShow = () => setShow(true);
   const template = [
@@ -60,6 +63,7 @@ function Navbar({ new_req_recieved, user_cred, onNavigate }) {
   const [new_server_image_preview, setnew_server_image_preview] =
     useState(server_input);
   const [new_server_image, setnew_server_image] = useState("");
+  const [serverError, setServerError] = useState("");
 
   function update_server_pic(e) {
     let file = e.target.files[0];
@@ -102,23 +106,41 @@ function Navbar({ new_req_recieved, user_cred, onNavigate }) {
   };
 
   const create_server = async () => {
-    const image_url = await upload_server_image();
+    const serverName = server_details.name.trim();
+    if (!serverName) {
+      setServerError("Server name cannot be empty.");
+      return false;
+    }
+    if (server_details.name.length > SERVER_NAME_MAX_LENGTH) {
+      setServerError(`Server name must be ${SERVER_NAME_MAX_LENGTH} characters or fewer.`);
+      return false;
+    }
 
-    const res = await fetch(`${API_BASE_URL}/servers/create_server`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-auth-token": localStorage.getItem("token"),
-      },
-      body: JSON.stringify({
-        server_details,
-        server_image: image_url,
-      }),
-    });
-    const data = await res.json();
-    if (data.status === 200) {
-      handleClose();
-      new_req_recieved(1);
+    try {
+      const image_url = await upload_server_image();
+
+      const res = await fetch(`${API_BASE_URL}/servers/create_server`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-auth-token": localStorage.getItem("token"),
+        },
+        body: JSON.stringify({
+          server_details: { ...server_details, name: serverName },
+          server_image: image_url,
+        }),
+      });
+      const data = await res.json();
+      if (data.status === 200) {
+        handleClose();
+        new_req_recieved(1);
+        return true;
+      }
+      setServerError(data.message || "Server could not be created.");
+      return false;
+    } catch {
+      setServerError("Server could not be created. Please try again.");
+      return false;
     }
   };
 
@@ -342,13 +364,21 @@ function Navbar({ new_req_recieved, user_cred, onNavigate }) {
                   </div>
                   <Input
                     value={server_details.name}
-                    onChange={(e) =>
+                    maxLength={SERVER_NAME_MAX_LENGTH}
+                    onChange={(e) => {
+                      setServerError("");
                       setserver_details({
                         ...server_details,
                         name: e.target.value,
-                      })
-                    }
+                      });
+                    }}
                   />
+                  <div className="flex items-center justify-between gap-3 text-xs font-semibold">
+                    <span className="text-red-300">{serverError}</span>
+                    <span className="ml-auto text-white/35">
+                      {server_details.name.length}/{SERVER_NAME_MAX_LENGTH}
+                    </span>
+                  </div>
                 </div>
               </div>
 
@@ -364,13 +394,23 @@ function Navbar({ new_req_recieved, user_cred, onNavigate }) {
                 </Button>
                 <Button
                   type="button"
-                  disabled={submit_button.create_button_state}
-                  onClick={() => {
-                    create_server();
+                  disabled={
+                    submit_button.create_button_state ||
+                    !server_details.name.trim() ||
+                    server_details.name.length > SERVER_NAME_MAX_LENGTH
+                  }
+                  onClick={async () => {
                     setsubmit_button({
                       create_button_state: true,
                       back_button_state: true,
                     });
+                    const created = await create_server();
+                    if (!created) {
+                      setsubmit_button({
+                        create_button_state: false,
+                        back_button_state: false,
+                      });
+                    }
                   }}
                 >
                   {submit_button.create_button_state ? (

--- a/frontend/src/lib/validationLimits.js
+++ b/frontend/src/lib/validationLimits.js
@@ -1,0 +1,2 @@
+export const MESSAGE_MAX_LENGTH = 2000;
+export const SERVER_NAME_MAX_LENGTH = 100;

--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
+    "test:validation": "node scripts/run-validation-unit.mjs",
     "test:auth:unit": "node scripts/run-auth-jwt-unit.mjs",
     "test:auth": "node scripts/run-auth-integration.mjs",
     "gmail:oauth-setup": "node scripts/gmail-oauth-setup.mjs"

--- a/server/scripts/run-validation-unit.mjs
+++ b/server/scripts/run-validation-unit.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+
+import {
+  MESSAGE_MAX_LENGTH,
+  SERVER_NAME_MAX_LENGTH,
+  validateMessageContent,
+  validateServerName,
+} from "../src/lib/validation.js";
+
+const emptyMessage = validateMessageContent("   ");
+assert.equal(emptyMessage.valid, false);
+assert.equal(emptyMessage.message, "Message cannot be empty");
+
+const longMessage = validateMessageContent("x".repeat(MESSAGE_MAX_LENGTH + 1));
+assert.equal(longMessage.valid, false);
+assert.equal(longMessage.message, "Message must be 2000 characters or fewer");
+
+const validMessage = validateMessageContent("  hello  ");
+assert.deepEqual(validMessage, { valid: true, value: "hello" });
+
+const emptyServerName = validateServerName("   ");
+assert.equal(emptyServerName.valid, false);
+assert.equal(emptyServerName.message, "Server name cannot be empty");
+
+const longServerName = validateServerName(
+  "x".repeat(SERVER_NAME_MAX_LENGTH + 1),
+);
+assert.equal(longServerName.valid, false);
+assert.equal(longServerName.message, "Server name must be 100 characters or fewer");
+
+const validServerName = validateServerName("  Piper Community  ");
+assert.deepEqual(validServerName, {
+  valid: true,
+  value: "Piper Community",
+});
+
+console.log("Validation unit checks passed.");

--- a/server/src/lib/validation.js
+++ b/server/src/lib/validation.js
@@ -1,0 +1,30 @@
+export const MESSAGE_MAX_LENGTH = 2000;
+export const SERVER_NAME_MAX_LENGTH = 100;
+
+function validateTrimmedString(value, maxLength, fieldName) {
+  if (typeof value !== "string") {
+    return { valid: false, message: `${fieldName} is required` };
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { valid: false, message: `${fieldName} cannot be empty` };
+  }
+
+  if (value.length > maxLength) {
+    return {
+      valid: false,
+      message: `${fieldName} must be ${maxLength} characters or fewer`,
+    };
+  }
+
+  return { valid: true, value: trimmed };
+}
+
+export function validateMessageContent(content) {
+  return validateTrimmedString(content, MESSAGE_MAX_LENGTH, "Message");
+}
+
+export function validateServerName(name) {
+  return validateTrimmedString(name, SERVER_NAME_MAX_LENGTH, "Server name");
+}

--- a/server/src/models/Chat.js
+++ b/server/src/models/Chat.js
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { MESSAGE_MAX_LENGTH } from "../lib/validation.js";
 
 const chatSchema = new mongoose.Schema({
   server_id: String,
@@ -8,7 +9,7 @@ const chatSchema = new mongoose.Schema({
       channel_name: String,
       chat_details: [
         {
-          content: String,
+          content: { type: String, maxlength: MESSAGE_MAX_LENGTH },
           sender_id: String,
           sender_name: String,
           sender_pic: String,

--- a/server/src/models/DirectMessageThread.js
+++ b/server/src/models/DirectMessageThread.js
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { MESSAGE_MAX_LENGTH } from "../lib/validation.js";
 
 const directMessageThreadSchema = new mongoose.Schema({
   participants: [String],
@@ -8,7 +9,7 @@ const directMessageThreadSchema = new mongoose.Schema({
       sender_name: String,
       sender_tag: String,
       sender_pic: String,
-      content: String,
+      content: { type: String, maxlength: MESSAGE_MAX_LENGTH },
       timestamp: Number,
     },
   ],

--- a/server/src/models/Server.js
+++ b/server/src/models/Server.js
@@ -1,7 +1,8 @@
 import mongoose from "mongoose";
+import { SERVER_NAME_MAX_LENGTH } from "../lib/validation.js";
 
 const serverSchema = new mongoose.Schema({
-  server_name: String,
+  server_name: { type: String, maxlength: SERVER_NAME_MAX_LENGTH },
   server_pic: String,
   users: [
     {

--- a/server/src/routes/chat.js
+++ b/server/src/routes/chat.js
@@ -9,6 +9,7 @@ import Server from "../models/Server.js";
 import User from "../models/User.js";
 import * as cache from "../lib/cache.js";
 import { isServerOwner } from "../lib/serverAuthorization.js";
+import { validateMessageContent } from "../lib/validation.js";
 import logger from "../lib/winston.js";
 import { getChats } from "../services/chatService.js";
 import { incrementServerUnread } from "../services/unreadService.js";
@@ -66,8 +67,15 @@ router.post("/store_message", expressRateLimit("chat"), async (req, res) => {
     profile_pic,
   } = req.body;
 
+  const messageValidation = validateMessageContent(message);
+  if (!messageValidation.valid) {
+    return res
+      .status(400)
+      .json({ status: 400, message: messageValidation.message });
+  }
+
   const chatMessage = {
-    content: message,
+    content: messageValidation.value,
     sender_id: id,
     sender_name: username,
     sender_pic: profile_pic,
@@ -119,7 +127,11 @@ router.post("/store_message", expressRateLimit("chat"), async (req, res) => {
       },
     };
     try {
-      const data = await Chat.updateOne({ server_id }, pushNewChannel);
+      const data = await Chat.updateOne(
+        { server_id },
+        pushNewChannel,
+        { runValidators: true },
+      );
       if (data && data.modifiedCount > 0) {
         await cache.del(`chat:${server_id}:${channel_id}`);
         await notifyServerRecipients();
@@ -146,6 +158,7 @@ router.post("/store_message", expressRateLimit("chat"), async (req, res) => {
       const data = await Chat.updateOne(
         { server_id, "channels.channel_id": channel_id },
         pushNewChat,
+        { runValidators: true },
       );
       if (data && data.modifiedCount > 0) {
         await cache.del(`chat:${server_id}:${channel_id}`);
@@ -209,8 +222,12 @@ router.post("/edit_server_message", async (req, res) => {
   }
   const senderId = user.id;
 
-  if (!server_id || !channel_id || !timestamp || !content || !content.trim()) {
-    return res.status(400).json({ status: 400, message: "Invalid input" });
+  const contentValidation = validateMessageContent(content);
+  if (!server_id || !channel_id || !timestamp || !contentValidation.valid) {
+    return res.status(400).json({
+      status: 400,
+      message: contentValidation.message || "Invalid input",
+    });
   }
 
   try {
@@ -233,7 +250,7 @@ router.post("/edit_server_message", async (req, res) => {
         .json({ status: 404, message: "Message not found" });
     }
 
-    message.content = content.trim();
+    message.content = contentValidation.value;
     await chatDoc.save();
     await cache.del(`chat:${server_id}:${channel_id}`);
 

--- a/server/src/routes/directMessages.js
+++ b/server/src/routes/directMessages.js
@@ -6,6 +6,7 @@ import jwt from "jsonwebtoken";
 import DirectMessageThread from "../models/DirectMessageThread.js";
 import User from "../models/User.js";
 import * as cache from "../lib/cache.js";
+import { validateMessageContent } from "../lib/validation.js";
 import { incrementDmUnread } from "../services/unreadService.js";
 import { getIO } from "../socket/runtime.js";
 
@@ -75,8 +76,12 @@ router.post("/send_direct_message", async (req, res) => {
 
   const { friend_id, content } = req.body;
 
-  if (!friend_id || !content || !content.trim()) {
-    return res.status(400).json({ message: "Invalid input", status: 400 });
+  const contentValidation = validateMessageContent(content);
+  if (!friend_id || !contentValidation.valid) {
+    return res.status(400).json({
+      message: contentValidation.message || "Invalid input",
+      status: 400,
+    });
   }
 
   const currentUser = await User.findOne({ _id: user.id }).lean();
@@ -99,7 +104,7 @@ router.post("/send_direct_message", async (req, res) => {
     sender_name: currentUser.username,
     sender_tag: currentUser.tag,
     sender_pic: currentUser.profile_pic,
-    content: content.trim(),
+    content: contentValidation.value,
     timestamp: Date.now(),
   };
 
@@ -111,7 +116,7 @@ router.post("/send_direct_message", async (req, res) => {
       $setOnInsert: { participants },
       $push: { messages: message },
     },
-    { upsert: true, returnDocument: "after" }
+    { upsert: true, returnDocument: "after", runValidators: true }
   );
   await cache.del(`dm:${participants[0]}:${participants[1]}`);
 
@@ -159,8 +164,12 @@ router.post("/edit_direct_message", async (req, res) => {
   }
 
   const { friend_id, timestamp, content } = req.body;
-  if (!friend_id || !timestamp || !content || !content.trim()) {
-    return res.status(400).json({ status: 400, message: "Invalid input" });
+  const contentValidation = validateMessageContent(content);
+  if (!friend_id || !timestamp || !contentValidation.valid) {
+    return res.status(400).json({
+      status: 400,
+      message: contentValidation.message || "Invalid input",
+    });
   }
 
   const participants = getThreadParticipants(user.id, friend_id);
@@ -178,7 +187,7 @@ router.post("/edit_direct_message", async (req, res) => {
     return res.status(404).json({ status: 404, message: "Message not found" });
   }
 
-  message.content = content.trim();
+  message.content = contentValidation.value;
   await thread.save();
   await cache.del(`dm:${participants[0]}:${participants[1]}`);
 

--- a/server/src/routes/servers.js
+++ b/server/src/routes/servers.js
@@ -11,6 +11,7 @@ import {
   canRemoveServerMember,
   isServerOwner,
 } from "../lib/serverAuthorization.js";
+import { validateServerName } from "../lib/validation.js";
 import { createChat } from "../services/chatService.js";
 import {
   addServerToUser,
@@ -33,9 +34,17 @@ router.post("/create_server", async (req, res) => {
     return res.status(401).json({ message: "Unauthorized", status: 401 });
   }
 
+  const serverDetails = req.body.server_details || {};
+  const nameValidation = validateServerName(serverDetails.name);
+  if (!nameValidation.valid) {
+    return res
+      .status(400)
+      .json({ status: 400, message: nameValidation.message });
+  }
+
   const serverTemplate = await createServerFromTemplate(
     user_id,
-    req.body.server_details,
+    { ...serverDetails, name: nameValidation.value },
     req.body.server_image
   );
   const addNewChat = await createChat(serverTemplate.server_id);
@@ -47,7 +56,7 @@ router.post("/create_server", async (req, res) => {
   const addServer = await addServerToUser(
     user_id.id,
     serverTemplate,
-    req.body.server_details.role
+    serverDetails.role
   );
 
   if (addServer) {

--- a/server/src/socket/index.js
+++ b/server/src/socket/index.js
@@ -1,5 +1,6 @@
 import User from "../models/User.js";
 import { buildServerTypingEvent } from "../lib/typingEvents.js";
+import { validateMessageContent } from "../lib/validation.js";
 
 const onlineUsers = new Map();
 
@@ -166,9 +167,25 @@ function attachSocketHandlers(io) {
     socket.on(
       "send_message",
       (channel_id, message, timestamp, sender_name, sender_tag, sender_pic) => {
-        socket.to(`channel:${channel_id}`).emit("recieve_message", {
+        const normalizedChannelId = String(channel_id || "");
+        if (
+          !normalizedChannelId ||
+          String(socket.data.active_channel_id || "") !== normalizedChannelId
+        ) {
+          return;
+        }
+
+        const messageValidation = validateMessageContent(message);
+        if (!messageValidation.valid) {
+          socket.emit("message_validation_error", {
+            message: messageValidation.message,
+          });
+          return;
+        }
+
+        socket.to(`channel:${normalizedChannelId}`).emit("recieve_message", {
           message_data: {
-            message,
+            message: messageValidation.value,
             timestamp,
             sender_name,
             sender_tag,


### PR DESCRIPTION
## Summary
- Added shared message and server-name validation limits across the frontend and backend.
- Trim and reject empty or over-limit content for server messages, direct messages, message edits, and server creation.
- Added MongoDB maxlength safeguards, legacy Socket.IO validation hardening, and a focused validation unit script.

Fixes #135

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tooling / developer experience

## Validation
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [ ] Server starts with `cd server && npm start`, if backend code changed
- [ ] I checked the feature or page I changed in the app

Additional checks:
- [x] `cd server && npm run test:validation`
- [x] `cd server && node --check src/routes/chat.js`
- [x] `cd server && node --check src/routes/directMessages.js`
- [x] `cd server && node --check src/routes/servers.js`
- [x] `cd server && node --check src/socket/index.js`

## Screenshots or Recording
Not included. The UI changes are character counters and validation messages on existing inputs.

## Notes for Reviewers
- Message content is capped at 2000 characters.
- Server names are capped at 100 characters.
- Whitespace-only values are rejected after trimming.
- `npm start` was not run locally because this workspace does not have `server/.env` / `MONGO_URI` configured.