### PR TITLE
fix: authenticate socket connections

### DIFF
--- a/frontend/src/components/auth/Auth.jsx
+++ b/frontend/src/components/auth/Auth.jsx
@@ -29,6 +29,7 @@ const Auth = () => {
         setauth_check(true);
       } else {
         localStorage.removeItem("token");
+        window.dispatchEvent(new Event("piperchat:auth-token"));
         setToken(null);
         setauth_check(false);
       }

--- a/frontend/src/components/settings/SettingsDialog.jsx
+++ b/frontend/src/components/settings/SettingsDialog.jsx
@@ -165,6 +165,7 @@ export default function SettingsDialog({ triggerClassName, icon: Icon }) {
         }
         if (data.token) {
           localStorage.setItem("token", data.token);
+          window.dispatchEvent(new Event("piperchat:auth-token"));
         }
         if (data.notification_preferences) {
           dispatch(set_notification_preferences(data.notification_preferences));
@@ -232,6 +233,7 @@ export default function SettingsDialog({ triggerClassName, icon: Icon }) {
       }
 
       localStorage.setItem("token", data.token);
+      window.dispatchEvent(new Event("piperchat:auth-token"));
       const decoded = jwt(data.token);
       
       // Update Redux with NEW data - use finalProfilePic if file was uploaded, otherwise use decoded value

--- a/frontend/src/components/socket/Socket.jsx
+++ b/frontend/src/components/socket/Socket.jsx
@@ -1,11 +1,47 @@
 import socketIO from "socket.io-client";
 import { SOCKET_URL } from "../../config";
 
+function getAuthToken() {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  return localStorage.getItem("token") || "";
+}
+
+const socketOptions = {
+  transports: ["websocket", "polling"],
+  withCredentials: true,
+  autoConnect: Boolean(getAuthToken()),
+  auth: (callback) => {
+    callback({ token: getAuthToken() });
+  },
+};
+
 const socket = SOCKET_URL
-  ? socketIO(SOCKET_URL, {
-      transports: ["websocket", "polling"],
-      withCredentials: true,
-    })
-  : socketIO();
+  ? socketIO(SOCKET_URL, socketOptions)
+  : socketIO(socketOptions);
+
+function refreshSocketAuth() {
+  const token = getAuthToken();
+  socket.auth = { token };
+
+  if (!token) {
+    socket.disconnect();
+    return;
+  }
+
+  if (socket.connected) {
+    socket.disconnect().connect();
+    return;
+  }
+
+  socket.connect();
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", refreshSocketAuth);
+  window.addEventListener("piperchat:auth-token", refreshSocketAuth);
+}
 
 export default socket;

--- a/frontend/src/lib/logout.js
+++ b/frontend/src/lib/logout.js
@@ -1,4 +1,5 @@
 export function logout() {
   localStorage.clear();
+  window.dispatchEvent(new Event("piperchat:auth-token"));
   window.location.replace("/");
 }

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "dev": "nodemon src/index.js",
     "test:auth:unit": "node scripts/run-auth-jwt-unit.mjs",
     "test:auth": "node scripts/run-auth-integration.mjs",
+    "test:socket:auth": "node scripts/run-socket-auth-unit.mjs",
     "gmail:oauth-setup": "node scripts/gmail-oauth-setup.mjs"
   },
   "author": "shunnu",

--- a/server/scripts/run-socket-auth-unit.mjs
+++ b/server/scripts/run-socket-auth-unit.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+
+process.env.ACCESS_TOKEN =
+  process.env.ACCESS_TOKEN ||
+  "socket-auth-unit-secret-minimum-length-32-characters";
+
+const jwt = await import("jsonwebtoken");
+const { isSocketUserClaimAllowed, verifySocketToken } = await import(
+  "../src/socket/index.js"
+);
+
+const token = jwt.default.sign(
+  {
+    id: "user-123",
+    email: "user@example.com",
+  },
+  process.env.ACCESS_TOKEN,
+);
+
+const verified = verifySocketToken(token);
+assert.equal(verified.userId, "user-123");
+assert.equal(verified.decoded.email, "user@example.com");
+
+assert.throws(
+  () => verifySocketToken(""),
+  /Socket authentication token is required/,
+);
+assert.throws(
+  () => verifySocketToken("not-a-valid-jwt"),
+  /jwt malformed|invalid token/,
+);
+
+const tokenWithoutUserId = jwt.default.sign(
+  { email: "missing-id@example.com" },
+  process.env.ACCESS_TOKEN,
+);
+assert.throws(
+  () => verifySocketToken(tokenWithoutUserId),
+  /missing a user id/,
+);
+
+const socket = {
+  data: {
+    authenticated_user_id: "user-123",
+  },
+};
+
+assert.equal(isSocketUserClaimAllowed(socket, "user-123"), true);
+assert.equal(isSocketUserClaimAllowed(socket, "victim-user"), false);
+assert.equal(isSocketUserClaimAllowed(socket, ""), false);
+assert.equal(isSocketUserClaimAllowed({ data: {} }, "user-123"), false);
+
+console.log("socket auth unit checks: passed");

--- a/server/src/socket/index.js
+++ b/server/src/socket/index.js
@@ -1,5 +1,7 @@
 import User from "../models/User.js";
+import config from "../config/index.js";
 import { buildServerTypingEvent } from "../lib/typingEvents.js";
+import jwt from "jsonwebtoken";
 
 const onlineUsers = new Map();
 
@@ -62,7 +64,69 @@ function setUserOffline(io, userId, socketId) {
   onlineUsers.set(normalizedUserId, activeSockets);
 }
 
+function extractSocketToken(socket) {
+  const authToken = socket.handshake?.auth?.token;
+  if (typeof authToken === "string" && authToken.trim()) {
+    return authToken.trim();
+  }
+
+  const headerToken = socket.handshake?.headers?.["x-auth-token"];
+  if (typeof headerToken === "string" && headerToken.trim()) {
+    return headerToken.trim();
+  }
+
+  const authorization = socket.handshake?.headers?.authorization;
+  if (typeof authorization === "string") {
+    const [scheme, token] = authorization.split(" ");
+    if (scheme?.toLowerCase() === "bearer" && token?.trim()) {
+      return token.trim();
+    }
+  }
+
+  return "";
+}
+
+function verifySocketToken(token) {
+  if (!token) {
+    throw new Error("Socket authentication token is required");
+  }
+
+  const decoded = jwt.verify(token, config.ACCESS_TOKEN);
+  const userId = decoded?.id;
+
+  if (!userId) {
+    throw new Error("Socket authentication token is missing a user id");
+  }
+
+  return {
+    decoded,
+    userId: String(userId),
+  };
+}
+
+function isSocketUserClaimAllowed(socket, userId) {
+  const claimedUserId = String(userId || "");
+  return Boolean(
+    claimedUserId &&
+      socket.data?.authenticated_user_id &&
+      claimedUserId === socket.data.authenticated_user_id,
+  );
+}
+
+function authenticateSocket(socket, next) {
+  try {
+    const { decoded, userId } = verifySocketToken(extractSocketToken(socket));
+    socket.data.auth_user = decoded;
+    socket.data.authenticated_user_id = userId;
+    next();
+  } catch {
+    next(new Error("Socket authentication failed"));
+  }
+}
+
 function attachSocketHandlers(io) {
+  io.use(authenticateSocket);
+
   io.on("connection", (socket) => {
     socket.on("channelCreated", (data) => {
       io.emit("newChannel", data);
@@ -72,6 +136,13 @@ function attachSocketHandlers(io) {
   io.on("connection", (socket) => {
     socket.on("get_userid", (user_id) => {
       const normalizedUserId = String(user_id);
+
+      if (!isSocketUserClaimAllowed(socket, normalizedUserId)) {
+        socket.emit("socket_auth_error", {
+          message: "Authenticated socket user does not match requested user",
+        });
+        return;
+      }
 
       if (socket.data.user_id === normalizedUserId) {
         socket.join(normalizedUserId);
@@ -237,4 +308,9 @@ function attachSocketHandlers(io) {
   });
 }
 
-export { attachSocketHandlers };
+export {
+  attachSocketHandlers,
+  authenticateSocket,
+  isSocketUserClaimAllowed,
+  verifySocketToken,
+};


### PR DESCRIPTION
## Summary
- require JWT authentication during the Socket.IO handshake
- bind the authenticated JWT user id to the socket session
- reject get_userid claims that do not match the authenticated user
- send the stored frontend JWT in socket auth and refresh socket auth when the token changes
- add a focused socket auth unit test for valid tokens, invalid tokens, missing user ids, and impersonation mismatch checks

Closes #145

## Validation
- cd server && npm run test:socket:auth
- cd server && npm run test:auth:unit
- cd frontend && npm run lint
- cd frontend && npm run build
- git diff --check

Notes:
- npm ci reports existing dependency audit advisories in server/frontend; this PR does not change dependencies.
- Vite build completes with the existing large chunk warning.