### PR TITLE
fix: add expiration to JWT tokens

### DIFF
--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -299,6 +299,7 @@ router.post("/signin", expressRateLimit("auth"), async (req, res) => {
     const token = jwt.sign(
       buildAuthUserJwtPayload(user),
       config.ACCESS_TOKEN,
+      { expiresIn: "7d" }
     );
     return res
       .status(201)

--- a/server/src/routes/profile.js
+++ b/server/src/routes/profile.js
@@ -156,7 +156,8 @@ router.patch("/", authToken, async (req, res) => {
 
     const token = jwt.sign(
       buildAuthUserJwtPayload(updated),
-      config.ACCESS_TOKEN
+      config.ACCESS_TOKEN,
+      { expiresIn: "7d" }
     );
 
     return res.status(200).json({


### PR DESCRIPTION
## Summary
Fixed JWT tokens being generated without expiration.

## Changes
- Added expiration time to authentication JWT tokens
- Updated signin token generation
- Updated profile update token regeneration
- Prevented perpetual session tokens

## Security Impact
Tokens now expire after 7 days, reducing risk from leaked or compromised JWTs.

Fixes #147

## Testing
- Verified JWT generation includes expiry
- Checked existing authentication flow