### PR TITLE
Add eye toggle to Confirm Password field

### DIFF
--- a/frontend/src/components/register/Register.jsx
+++ b/frontend/src/components/register/Register.jsx
@@ -195,6 +195,8 @@ function Register() {
   const [submitting, setSubmitting] = useState(false);
   const [verifying, setVerifying] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
 
   const months = [
     "January", "February", "March", "April", "May", "June",
@@ -455,16 +457,32 @@ function Register() {
             <div>
               <Label>Confirm Password</Label>
               <div className="space-y-1.5">
-                <StyledInput
-                  name="confirm_password"
-                  type="password"
-                  autoComplete="new-password"
-                  value={user_values.confirm_password}
-                  onChange={handle_user_values}
-                  required
-                  disabled={submitting || verifying}
-                  placeholder="Confirm your password"
-                />
+                <div className="relative">
+                  <StyledInput
+                    name="confirm_password"
+                    type={showConfirmPassword ? "text" : "password"}
+                    autoComplete="new-password"
+                    value={user_values.confirm_password}
+                    onChange={handle_user_values}
+                    required
+                    disabled={submitting || verifying}
+                    placeholder="Confirm your password"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2"
+                    style={{ cursor: "pointer" }}
+                    aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                  >
+                    {showConfirmPassword ? (
+                      <FiEyeOff size={14} style={{ color: "var(--text-secondary)" }} />
+                    ) : (
+                      <FiEye size={14} style={{ color: "var(--text-secondary)" }} />
+                    )}
+                  </button>
+                </div>
+
                 <AnimatePresence>
                   {password_validation && (
                     <motion.div
@@ -484,6 +502,7 @@ function Register() {
                 </AnimatePresence>
               </div>
             </div>
+
 
             {/* Date of Birth */}
             <div


### PR DESCRIPTION
### Problem
The Confirm Password field on the registration page lacks a visibility 
toggle (eye icon), while the Password field has one. This creates an 
inconsistent UX and makes it harder for users to verify their input.

### Solution
- Added `showConfirmPassword` state for independent toggle control
- Wrapped the Confirm Password input in a `relative` div and added an 
  eye icon button (FiEye / FiEyeOff) matching the Password field's style
- Toggle switches input type between `text` and `password`
- Includes proper `aria-label` for accessibility
