### PR TITLE
fix invalid rgba in AuthShell

### DIFF
--- a/frontend/src/components/auth/AuthShell.jsx
+++ b/frontend/src/components/auth/AuthShell.jsx
@@ -145,7 +145,7 @@ export default function AuthShell({ children }) {
                   <div className="text-xs font-bold" style={{ color: "rgba(255,255,255,0.85)" }}>
                     {item.label}
                   </div>
-                  <div className="text-xs mt-0.5" style={{ color: "rgba(255,255,255,0.65))" }}>
+                  <div className="text-xs mt-0.5" style={{ color: "rgba(255,255,255,0.65)" }}>
                     {item.sub}
                   </div>
                 </motion.div>


### PR DESCRIPTION
What changed
- Fixed the invalid `rgba(255,255,255,0.65))` value in `AuthShell.jsx`.
- The secondary feature-card description text now uses a valid semi-transparent white color again.

Why
- The extra closing parenthesis broke the CSS value, so the browser ignored the intended styling.

Validation
- git diff --check
- npm run build

Closes #151