### PR TITLE
fix OTP verification error response

### DIFF
--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -204,7 +204,7 @@ router.post("/verify", expressRateLimit("otp"), async (req, res) => {
           status: 201,
         });
       }
-      return res.status(432).json({ error: "incorrect passowrd", status: 432 });
+      return res.status(401).json({ error: "incorrect OTP", status: 401 });
     }
 
     const otp = generateOTP();


### PR DESCRIPTION
What changed
- Replaced the OTP verification failure response with a standard `401` status.
- Updated the message to `incorrect OTP`.

Why
- The previous response used a non-standard status code and referred to a password even though the endpoint validates an OTP.

Validation
- git diff --check
- node --check server/src/routes/auth.js

Closes #174