### PR TITLE
[codex] add input length guards

### DIFF
--- a/frontend/src/components/chat/messages/ValidChat.jsx
+++ b/frontend/src/components/chat/messages/ValidChat.jsx
@@ -9,6 +9,8 @@ import { Button } from "../../ui/button";
 import { resolveProfilePic, handleImageError } from "../../../shared/imageFallbacks";
 import { API_BASE_URL } from "../../../config";
 
+const MAX_CHAT_MESSAGE_LENGTH = 2000;
+
 function ValidChat() {
   const dispatch = useDispatch();
   const url = API_BASE_URL;
@@ -49,7 +51,7 @@ function ValidChat() {
   };
 
   const handleMessageChange = (e) => {
-    const nextMessage = e.target.value;
+    const nextMessage = e.target.value.slice(0, MAX_CHAT_MESSAGE_LENGTH);
     setchat_message(nextMessage);
 
     if (!channel_id || !server_id || !id) {
@@ -85,6 +87,7 @@ function ValidChat() {
 
   const sendNow = async () => {
     if (!chat_message.trim()) return;
+    if (chat_message.length > MAX_CHAT_MESSAGE_LENGTH) return;
     const message_to_send = chat_message;
     const timestamp = Date.now();
     setchat_message("");
@@ -559,7 +562,13 @@ function ValidChat() {
         </div>
       ) : null}
 
-      <div className="border-t border-white/10 bg-black/25 p-3">
+        <div className="border-t border-white/10 bg-black/25 p-3">
+        <div className="mb-2 flex items-center justify-between text-[11px] font-semibold text-white/35">
+          <span>Message</span>
+          <span>
+            {chat_message.length}/{MAX_CHAT_MESSAGE_LENGTH}
+          </span>
+        </div>
         <div className="flex items-center gap-2">
           <Input
             value={chat_message}
@@ -571,6 +580,7 @@ function ValidChat() {
             }}
             onChange={handleMessageChange}
             placeholder={`Message #${channel_name}`}
+            maxLength={MAX_CHAT_MESSAGE_LENGTH}
             className="flex-1"
           />
           <Button

--- a/frontend/src/components/navbar/Navbar.jsx
+++ b/frontend/src/components/navbar/Navbar.jsx
@@ -20,6 +20,8 @@ import { Input } from "../ui/input";
 import { close_direct_message } from "../../store/directMessageSlice";
 import { API_BASE_URL } from "../../config";
 
+const MAX_SERVER_NAME_LENGTH = 100;
+
 function Navbar({ new_req_recieved, user_cred, onNavigate }) {
   const dispatch = useDispatch();
   const unreadServers = useSelector((state) => state.unread.servers);
@@ -338,7 +340,12 @@ function Navbar({ new_req_recieved, user_cred, onNavigate }) {
 
                 <div className="flex-1 space-y-2">
                   <div className="text-xs font-extrabold tracking-widest text-white/45">
-                    SERVER NAME
+                    <div className="flex items-center justify-between">
+                      <span>SERVER NAME</span>
+                      <span>
+                        {server_details.name.length}/{MAX_SERVER_NAME_LENGTH}
+                      </span>
+                    </div>
                   </div>
                   <Input
                     value={server_details.name}
@@ -348,6 +355,7 @@ function Navbar({ new_req_recieved, user_cred, onNavigate }) {
                         name: e.target.value,
                       })
                     }
+                    maxLength={MAX_SERVER_NAME_LENGTH}
                   />
                 </div>
               </div>

--- a/server/src/routes/chat.js
+++ b/server/src/routes/chat.js
@@ -17,6 +17,7 @@ import { getIO } from "../socket/runtime.js";
 import expressRateLimit from "../middleware/rateLimit.js";
 
 const router = express.Router();
+const MAX_CHAT_MESSAGE_LENGTH = 2000;
 
 async function shouldSendNotification(userId, preferenceKey) {
   try {
@@ -66,8 +67,19 @@ router.post("/store_message", expressRateLimit("chat"), async (req, res) => {
     profile_pic,
   } = req.body;
 
+  if (
+    typeof message !== "string" ||
+    !message.trim() ||
+    message.length > MAX_CHAT_MESSAGE_LENGTH
+  ) {
+    return res.status(400).json({
+      status: 400,
+      message: `Message must be 1-${MAX_CHAT_MESSAGE_LENGTH} characters.`,
+    });
+  }
+
   const chatMessage = {
-    content: message,
+    content: message.trim(),
     sender_id: id,
     sender_name: username,
     sender_pic: profile_pic,
@@ -209,7 +221,14 @@ router.post("/edit_server_message", async (req, res) => {
   }
   const senderId = user.id;
 
-  if (!server_id || !channel_id || !timestamp || !content || !content.trim()) {
+  if (
+    !server_id ||
+    !channel_id ||
+    !timestamp ||
+    typeof content !== "string" ||
+    !content.trim() ||
+    content.length > MAX_CHAT_MESSAGE_LENGTH
+  ) {
     return res.status(400).json({ status: 400, message: "Invalid input" });
   }
 

--- a/server/src/routes/servers.js
+++ b/server/src/routes/servers.js
@@ -21,6 +21,7 @@ import {
 import { getIO } from "../socket/runtime.js";
 
 const router = express.Router();
+const MAX_SERVER_NAME_LENGTH = 100;
 
 router.post("/create_server", async (req, res) => {
   let user_id;
@@ -33,9 +34,22 @@ router.post("/create_server", async (req, res) => {
     return res.status(401).json({ message: "Unauthorized", status: 401 });
   }
 
+  const serverDetails = req.body.server_details || {};
+  const normalizedName = String(serverDetails.name || "").trim();
+  if (
+    typeof serverDetails.name !== "string" ||
+    !normalizedName ||
+    normalizedName.length > MAX_SERVER_NAME_LENGTH
+  ) {
+    return res.status(400).json({
+      status: 400,
+      message: `Server name must be 1-${MAX_SERVER_NAME_LENGTH} characters.`,
+    });
+  }
+
   const serverTemplate = await createServerFromTemplate(
     user_id,
-    req.body.server_details,
+    { ...serverDetails, name: normalizedName },
     req.body.server_image
   );
   const addNewChat = await createChat(serverTemplate.server_id);


### PR DESCRIPTION
## What changed
- Added backend validation for chat messages so empty or oversized messages are rejected before save.
- Added backend validation for server names so create-server requests are normalized and capped.
- Added frontend length caps and live counters for the chat composer and server name input.

## Why
The app was accepting free-form input without clear length guardrails. That created a mismatch between the UI and server expectations and left room for invalid payloads.

## Impact
Users now get immediate feedback in the UI, and the backend rejects invalid requests consistently.

## Validation
- `git diff --check`
- `node --check server/src/routes/chat.js`
- `node --check server/src/routes/servers.js`
- `npm run build` in `frontend`

Closes #135
