### PR TITLE
improve password toggle contrast

### DIFF
--- a/frontend/src/components/login/Login.jsx
+++ b/frontend/src/components/login/Login.jsx
@@ -219,16 +219,26 @@ function Login() {
               required
               disabled={submitting}
               placeholder="••••••••"
+              style={{ paddingRight: "3rem" }}
             />
             <button
-                type="button"
-                onClick={() => setShowPassword(!showPassword)}
-                className="absolute right-3 top-[70%] -translate-y-1/2"
-                style={{cursor : 'pointer'}}
-              >
-                {showPassword ? ( <FiEyeOff size={14} style={{ color: "var(--text-secondary)" }} />) : (
-                  <FiEye size={14} style={{ color: "var(--text-secondary)" }} />)}
-              </button>
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              aria-label={showPassword ? "Hide password" : "Show password"}
+              className="absolute right-3 top-[70%] -translate-y-1/2 inline-flex h-8 w-8 items-center justify-center rounded-lg border transition-colors duration-200"
+              style={{
+                cursor: "pointer",
+                background: "rgba(255,255,255,0.08)",
+                borderColor: "rgba(255,255,255,0.12)",
+                color: "rgba(255,255,255,0.82)",
+              }}
+            >
+              {showPassword ? (
+                <FiEyeOff size={16} style={{ color: "currentColor" }} />
+              ) : (
+                <FiEye size={16} style={{ color: "currentColor" }} />
+              )}
+            </button>
           </div>
 
           <div className="pt-1">


### PR DESCRIPTION
## What changed
- Increased contrast on the password visibility toggle in the login form.
- Added a subtle button background, border, and larger hit area so the control is easier to notice and tap.
- Added right padding to the password field so the icon no longer crowds the typed text.

## Why
The eye icon was blending into the password input styling, making the visibility toggle hard to see on the login screen.

## Impact
Login is a little more accessible and the password toggle is now much easier to discover and use.

## Validation
- `git diff --check`
- `npm run build` in `frontend`

Closes #211
