### PR TITLE
add password strength hints

### DIFF
--- a/frontend/src/components/auth/PasswordStrengthGuide.jsx
+++ b/frontend/src/components/auth/PasswordStrengthGuide.jsx
@@ -1,0 +1,98 @@
+const PASSWORD_MIN_LENGTH = 8;
+
+const PASSWORD_REQUIREMENTS = [
+  {
+    id: "length",
+    label: `At least ${PASSWORD_MIN_LENGTH} characters`,
+    test: (password) => password.length >= PASSWORD_MIN_LENGTH,
+  },
+  {
+    id: "uppercase",
+    label: "One uppercase letter",
+    test: (password) => /[A-Z]/.test(password),
+  },
+  {
+    id: "number",
+    label: "One number",
+    test: (password) => /\d/.test(password),
+  },
+  {
+    id: "special",
+    label: "One special character",
+    test: (password) => /[^A-Za-z0-9]/.test(password),
+  },
+];
+
+function getPasswordStrength(password) {
+  const metCount = PASSWORD_REQUIREMENTS.filter((rule) => rule.test(password)).length;
+
+  if (!password) {
+    return {
+      label: "Start typing",
+      color: "rgba(255,255,255,0.35)",
+      width: "0%",
+    };
+  }
+
+  if (metCount <= 1) {
+    return { label: "Weak", color: "#f87171", width: "25%" };
+  }
+
+  if (metCount === 2) {
+    return { label: "Fair", color: "#fbbf24", width: "50%" };
+  }
+
+  if (metCount === 3) {
+    return { label: "Good", color: "#4ade80", width: "75%" };
+  }
+
+  return { label: "Strong", color: "#22c55e", width: "100%" };
+}
+
+export default function PasswordStrengthGuide({ password }) {
+  const strength = getPasswordStrength(password);
+
+  return (
+    <div className="mt-2 space-y-2 rounded-2xl border border-white/10 bg-white/3 p-3">
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-3 text-[11px] font-semibold uppercase tracking-[0.18em]">
+          <span style={{ color: "rgba(255,255,255,0.45)" }}>Password strength</span>
+          <span style={{ color: strength.color }}>{strength.label}</span>
+        </div>
+        <div className="h-1.5 overflow-hidden rounded-full bg-white/8">
+          <div
+            className="h-full rounded-full transition-all duration-200"
+            style={{
+              width: strength.width,
+              background:
+                "linear-gradient(90deg, #ef4444 0%, #f59e0b 33%, #a855f7 66%, #22c55e 100%)",
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-1.5 sm:grid-cols-2">
+        {PASSWORD_REQUIREMENTS.map((rule) => {
+          const passed = rule.test(password);
+
+          return (
+            <div
+              key={rule.id}
+              className="flex items-center gap-2 rounded-xl px-3 py-2 text-[11px] font-medium"
+              style={{
+                background: passed ? "rgba(34,197,94,0.12)" : "rgba(255,255,255,0.03)",
+                border: passed ? "1px solid rgba(34,197,94,0.24)" : "1px solid rgba(255,255,255,0.08)",
+                color: passed ? "#86efac" : "rgba(255,255,255,0.52)",
+              }}
+            >
+              <span className="text-xs">{passed ? "✓" : "•"}</span>
+              <span>{rule.label}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export { PASSWORD_MIN_LENGTH };

--- a/frontend/src/components/login/Login.jsx
+++ b/frontend/src/components/login/Login.jsx
@@ -4,6 +4,7 @@ import AuthShell from "../auth/AuthShell";
 import { motion, AnimatePresence } from "framer-motion";
 import { FiEye, FiEyeOff } from "react-icons/fi";
 import { API_BASE_URL } from "../../config";
+import PasswordStrengthGuide from "../auth/PasswordStrengthGuide";
 
 
 function Label({ children }) {
@@ -229,6 +230,7 @@ function Login() {
                 {showPassword ? ( <FiEyeOff size={14} style={{ color: "var(--text-secondary)" }} />) : (
                   <FiEye size={14} style={{ color: "var(--text-secondary)" }} />)}
               </button>
+            <PasswordStrengthGuide password={user_values.password} />
           </div>
 
           <div className="pt-1">

--- a/frontend/src/components/register/Register.jsx
+++ b/frontend/src/components/register/Register.jsx
@@ -4,6 +4,7 @@ import AuthShell from "../auth/AuthShell";
 import { motion, AnimatePresence } from "framer-motion";
 import { FiEye, FiEyeOff } from "react-icons/fi";
 import { API_BASE_URL } from "../../config";
+import PasswordStrengthGuide, { PASSWORD_MIN_LENGTH } from "../auth/PasswordStrengthGuide";
 import {
   Dialog,
   DialogContent,
@@ -281,7 +282,9 @@ function Register() {
           setalert_message("Please fill in all fields.");
           setalert_box(true);
         } else if (data.status === 400) {
-          setalert_message("Password must be at least 7 characters long.");
+          setalert_message(
+            `Password must be at least ${PASSWORD_MIN_LENGTH} characters long.`
+          );
           setalert_box(true);
         } else {
           setalert_message("Registration failed. Please try again.");
@@ -431,7 +434,7 @@ function Register() {
                   onChange={handle_user_values}
                   required
                   disabled={submitting || verifying}
-                  placeholder="At least 7 characters"
+                  placeholder={`At least ${PASSWORD_MIN_LENGTH} characters`}
                 />
                 <button
                   type="button"
@@ -447,9 +450,7 @@ function Register() {
                   )}
                 </button>
               </div>
-              <p className="mt-1 text-[11px]" style={{ color: "rgba(255,255,255,0.3)" }}>
-                Minimum 7 characters.
-              </p>
+              <PasswordStrengthGuide password={user_values.password} />
             </div>
 
             <div>

--- a/server/src/services/userService.js
+++ b/server/src/services/userService.js
@@ -26,7 +26,7 @@ export function signup(email, username, password, dob) {
       if (!username || !email || !password || !dob) {
         return { message: "wrong input", status: 204 };
       }
-      if (password.length < 7) {
+      if (password.length < 8) {
         return { message: "password length", status: 400 };
       }
       return { message: true };


### PR DESCRIPTION
## What changed
- Added a shared password strength guide for the auth screens.
- Show real-time feedback for length, uppercase letters, numbers, and special characters.
- Added a live strength bar and per-rule checklist to login and signup password fields.
- Bumped signup password minimum length to 8 characters so the UI hint matches server validation.

## Why
Users were only seeing a generic invalid-credentials error after submit, with no guidance on what the password needed.

## Impact
People now get immediate feedback while typing, which makes signup clearer and reduces silent validation failures.

## Validation
- `git diff --check`
- `node --check server/src/services/userService.js`
- `npm run build` in `frontend`

Closes #191
