### PR TITLE
link contributor guide from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ All backend APIs are mounted under:
 - `npm run build` → production build
 - `npm run lint` → ESLint
 
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. It includes the PR template, commit message format, and the local validation checks we expect contributors to run before review.
+
 ## Logging
 
 The backend uses Winston for structured logging.


### PR DESCRIPTION
## What changed
- Added a dedicated Contributing section to the README.
- Linked contributors to `CONTRIBUTING.md` so PR format, commit style, and validation steps are easy to find.

## Why
The repo already had the contributor guide, but the README did not point new contributors to it clearly.

## Impact
Onboarding is a little smoother and new contributors have a single obvious starting point for setup and pull requests.

## Validation
- `git diff --check`

Closes #194
