### PR TITLE
add bio field to profiles

### DIFF
--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -11,6 +11,7 @@ import {
   change_username,
   change_tag,
   option_profile_pic,
+  set_bio,
   option_user_id,
   set_notification_preferences,
 } from "../../store/userCredsSlice";
@@ -143,11 +144,12 @@ function Dashboard() {
     if (token) {
       try {
         const user_creds = jwt(token);
-        const { username, tag, profile_pic, id, notification_preferences } = user_creds;
+        const { username, tag, profile_pic, bio, id, notification_preferences } = user_creds;
 
         dispatch(change_username(username));
         dispatch(change_tag(tag));
         dispatch(option_profile_pic(resolveProfilePic(profile_pic, username)));
+        dispatch(set_bio(bio || ""));
         dispatch(option_user_id(id));
 
         dispatch(

--- a/frontend/src/components/settings/SettingsDialog.jsx
+++ b/frontend/src/components/settings/SettingsDialog.jsx
@@ -6,7 +6,7 @@ import { Save, Lock, Bell, User, Image, CheckCircle2, AlertCircle, Loader2, Penc
 
 import { API_BASE_URL } from "../../config";
 import { resolveProfilePic, handleImageError } from "../../shared/imageFallbacks";
-import { change_tag, change_username, option_profile_pic, set_notification_preferences } from "../../store/userCredsSlice";
+import { change_tag, change_username, option_profile_pic, set_bio, set_notification_preferences } from "../../store/userCredsSlice";
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from "../ui/dialog";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -83,6 +83,7 @@ export default function SettingsDialog({ triggerClassName, icon: Icon }) {
   const [open, setOpen] = useState(false);
   const [activeTab, setActiveTab] = useState("user");
   const [displayName, setDisplayName] = useState(user.username || "");
+  const [bio, setBio] = useState(user.bio || "");
   const [file, setFile] = useState(null);
   const [previewUrl, setPreviewUrl] = useState("");
   const [saving, setSaving] = useState(false);
@@ -113,6 +114,7 @@ export default function SettingsDialog({ triggerClassName, icon: Icon }) {
   useEffect(() => {
     if (open && user.username) {
       setDisplayName(user.username);
+      setBio(user.bio || "");
     }
     if (open) {
       setActiveTab("user");
@@ -127,6 +129,7 @@ export default function SettingsDialog({ triggerClassName, icon: Icon }) {
 
   const reset = () => {
     setDisplayName(user.username || "");
+    setBio(user.bio || "");
     setFile(null);
     setPreviewUrl("");
     setSaving(false);
@@ -181,9 +184,15 @@ export default function SettingsDialog({ triggerClassName, icon: Icon }) {
 
   const saveProfile = async () => {
     const nextName = String(displayName || "").trim().replace(/\s+/g, " ");
+    const nextBio = String(bio || "").trim();
 
     if (nextName.length < 2 || nextName.length > 32) {
       setError("Name must be 2–32 characters.");
+      return;
+    }
+
+    if (nextBio.length > 200) {
+      setError("Bio must be 200 characters or less.");
       return;
     }
 
@@ -212,6 +221,7 @@ export default function SettingsDialog({ triggerClassName, icon: Icon }) {
         body: JSON.stringify({
           username: nextName,
           profile_pic: finalProfilePic || "",
+          bio: nextBio,
         }),
       });
 
@@ -243,6 +253,7 @@ export default function SettingsDialog({ triggerClassName, icon: Icon }) {
       dispatch(change_username(decoded.username));
       dispatch(change_tag(decoded.tag));
       dispatch(option_profile_pic(updatedProfilePic));
+      dispatch(set_bio(decoded.bio || ""));
       if (decoded.notification_preferences) {
         dispatch(set_notification_preferences(decoded.notification_preferences));
       }
@@ -421,6 +432,21 @@ export default function SettingsDialog({ triggerClassName, icon: Icon }) {
                         placeholder="Your display name"
                         className="h-9 border-white/5 bg-white/[0.03] text-sm text-white placeholder:text-white/10 focus:border-violet-500/40 focus:bg-white/[0.05]"
                       />
+                      <div className="space-y-2 pt-1">
+                        <label className="text-[10px] font-bold uppercase tracking-[0.2em] text-white/30">Bio / About</label>
+                        <textarea
+                          value={bio}
+                          onChange={(e) => setBio(e.target.value)}
+                          maxLength={200}
+                          rows={4}
+                          placeholder="Write a short bio"
+                          className="min-h-[96px] w-full resize-none rounded-xl border border-white/5 bg-white/[0.03] px-3 py-2 text-sm text-white outline-none transition placeholder:text-white/10 focus:border-violet-500/40 focus:bg-white/[0.05]"
+                        />
+                        <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.18em] text-white/25">
+                          <span>Visible on your profile</span>
+                          <span>{bio.length}/200</span>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/components/sidebar/Navbar2.jsx
+++ b/frontend/src/components/sidebar/Navbar2.jsx
@@ -12,6 +12,7 @@ function Navbar2({ friends, onNavigate }) {
   // user details from redux
   const username = useSelector((state) => state.user_info.username);
   const tag = useSelector((state) => state.user_info.tag);
+  const bio = useSelector((state) => state.user_info.bio);
   const rawProfilePic = useSelector((state) => state.user_info.profile_pic);
   const profile_pic = resolveProfilePic(rawProfilePic, username);
 
@@ -57,6 +58,11 @@ function Navbar2({ friends, onNavigate }) {
             {username}
           </div>
           <div className="text-xs font-semibold text-white/50">#{tag}</div>
+          {bio ? (
+            <div className="mt-1 truncate text-[11px] leading-snug text-white/35">
+              {bio}
+            </div>
+          ) : null}
         </div>
         <div className="flex items-center gap-2">
           {footerButton("Unmute", MicOff)}

--- a/frontend/src/store/userCredsSlice.js
+++ b/frontend/src/store/userCredsSlice.js
@@ -6,6 +6,7 @@ export const user_creds = createSlice({
     username: "",
     tag: "",
     profile_pic: "",
+    bio: "",
     id: 0,
     notification_preferences: {
       direct_messages: true,
@@ -24,6 +25,9 @@ export const user_creds = createSlice({
     option_profile_pic: (state, action) => {
       state.profile_pic = action.payload;
     },
+    set_bio: (state, action) => {
+      state.bio = action.payload;
+    },
     option_user_id: (state, action) => {
       state.id = action.payload;
     },
@@ -38,9 +42,9 @@ export const {
   change_username,
   change_tag,
   option_profile_pic,
+  set_bio,
   option_user_id,
   set_notification_preferences,
 } = user_creds.actions;
 
 export default user_creds.reducer;
-  

--- a/server/src/lib/authJwtPayload.js
+++ b/server/src/lib/authJwtPayload.js
@@ -9,6 +9,7 @@ export function buildAuthUserJwtPayload(user) {
     username: user.username ?? "",
     tag: user.tag ?? "",
     profile_pic: user.profile_pic ?? "",
+    bio: user.bio ?? "",
     notification_preferences: {
       direct_messages: true,
       friend_requests: true,

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -8,6 +8,7 @@ const userSchema = new mongoose.Schema(
     password: String,
     dob: String,
     profile_pic: String,
+    bio: String,
     authorized: Boolean,
     servers: [
       {

--- a/server/src/routes/profile.js
+++ b/server/src/routes/profile.js
@@ -30,6 +30,16 @@ function isValidProfilePicUrl(value) {
   return false;
 }
 
+function normalizeBio(value) {
+  return String(value || "").trim().replace(/\r\n/g, "\n");
+}
+
+function isValidBio(value) {
+  if (value === undefined) return true;
+  if (typeof value !== "string") return false;
+  return value.length <= 200;
+}
+
 async function propagateUserIdentity({ userId, username, profile_pic }) {
   const arrayUpdates = [];
 
@@ -111,6 +121,8 @@ router.patch("/", authToken, async (req, res) => {
         : normalizeUsername(req.body.username);
     const requestedProfilePic =
       req.body.profile_pic === undefined ? undefined : req.body.profile_pic;
+    const requestedBio =
+      req.body.bio === undefined ? undefined : normalizeBio(req.body.bio);
 
     if (
       requestedUsername !== undefined &&
@@ -132,9 +144,17 @@ router.patch("/", authToken, async (req, res) => {
       });
     }
 
+    if (requestedBio !== undefined && !isValidBio(req.body.bio)) {
+      return res.status(400).json({
+        message: "Bio must be 200 characters or less.",
+        status: 400,
+      });
+    }
+
     const $set = {};
     if (requestedUsername !== undefined) $set.username = requestedUsername;
     if (requestedProfilePic !== undefined) $set.profile_pic = requestedProfilePic;
+    if (requestedBio !== undefined) $set.bio = requestedBio;
 
     if (Object.keys($set).length === 0) {
       return res.status(400).json({ message: "No changes", status: 400 });
@@ -168,6 +188,7 @@ router.patch("/", authToken, async (req, res) => {
         username: updated.username,
         tag: updated.tag,
         profile_pic: updated.profile_pic,
+        bio: updated.bio ?? "",
       },
     });
   } catch (err) {


### PR DESCRIPTION
## What changed
- Added a Bio/About field to profile settings with a live character counter.
- Persisted the bio through the profile API and user JWT payload.
- Stored the bio on the user record and surfaced it in the profile sidebar card.

## Why
Users could edit their display name and avatar, but there was no place for a short profile bio.

## Impact
Profiles feel more complete and the bio now survives saves, refreshes, and token-based app loads.

## Validation
- `git diff --check`
- `node --check server/src/routes/profile.js`
- `node --check server/src/lib/authJwtPayload.js`
- `node --check server/src/models/User.js`
- `npm run build` in `frontend`

Closes #212
