### PR TITLE
fix: close theme dropdown when clicking outside the menu

### DIFF
--- a/frontend/src/components/friends/header/TopnavDashboard.jsx
+++ b/frontend/src/components/friends/header/TopnavDashboard.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState, useEffect, useRef } from 'react';
 import friends_icon from "../../../images/friends.svg";
 import {
   Inbox,
@@ -30,6 +30,19 @@ function TopnavDashboard({button_status, onToggleSidebar}) {
     const active = useSelector((state) => state.selected_option.value);
     const { setTheme } = useTheme();
     const [showThemes, setShowThemes] = useState(false);
+    const themesRef = useRef(null);
+
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (showThemes && themesRef.current && !themesRef.current.contains(event.target)) {
+        setShowThemes(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [showThemes]);
 
   function change_option_value(option_number,option_name,status,text){
     dispatch(close_direct_message())
@@ -174,7 +187,7 @@ function TopnavDashboard({button_status, onToggleSidebar}) {
 
       <div className="flex items-center gap-2">
 
-  <div className="relative">
+  <div ref={themesRef} className="relative">
     <button
       type="button"
       onClick={() => setShowThemes(!showThemes)}


### PR DESCRIPTION
### Description
This PR fixes an issue where the Theme selection dropdown menu would remain open even after a user clicked outside of its container. 

I implemented a React custom outside-click handler using `useRef` and a global event listener inside a `useEffect` hook. Now, clicking anywhere outside the theme menu seamlessly closes it, improving the overall user experience and interface navigation.

### Changes Made
* Added a `themesRef` using React's `useRef` hook onto the outer container wrapper of the Theme section in `TopnavDashboard.jsx`.
* Implemented a `handleClickOutside` listener within a `useEffect` hook to detect clicks outside the wrapper.
* Correctly toggles the `showThemes` state back to `false` when an external click is detected.
* Cleaned up the event listener on component unmount to prevent potential memory leaks.

### How to Test
1. Spin up both the frontend and server locally.
2. Click the **Theme** button on the top navigation bar dashboard to open the theme selection dropdown.
3. Click anywhere completely outside the dropdown container (e.g., main workspace area or sidebar).
4. **Expected Result:** The theme dropdown menu should immediately close.

### Checklists
- [x] My code follows the code style of this project.
- [x] My changes generate no new warnings or errors.
- [x] I have verified the structural implementation of the React hooks.

closes #239 