### PR TITLE
security(#199): Apply authToken middleware to critical message endpoints

### DIFF
--- a/server/src/routes/chat.js
+++ b/server/src/routes/chat.js
@@ -18,6 +18,7 @@ import expressRateLimit from "../middleware/rateLimit.js";
 
 import { deleteServerMessageValidator, editServerMessageValidator, getMessagesValidator, storeMessageValidator } from "../validators/chat.js";
 import validate from "../middleware/validate.js";
+import { authToken } from "../middleware/auth.js";
 
 const router = express.Router();
 
@@ -56,7 +57,7 @@ function findChatMessage(channel, timestamp, senderId) {
   );
 }
 
-router.post("/store_message", expressRateLimit("chat"), storeMessageValidator, validate, async (req, res) => {
+router.post("/store_message", authToken, expressRateLimit("chat"), storeMessageValidator, validate, async (req, res) => {
   const {
     message,
     server_id,
@@ -169,7 +170,7 @@ router.post("/store_message", expressRateLimit("chat"), storeMessageValidator, v
   }
 });
 
-router.post("/get_messages", getMessagesValidator, validate, async (req, res) => {
+router.post("/get_messages", authToken, getMessagesValidator, validate, async (req, res) => {
   const { channel_id, server_id } = req.body;
 
   try {


### PR DESCRIPTION
## Problem Statement

CRITICAL SECURITY: Missing Authentication on Critical Endpoints

Chat message endpoints (/store_message, /get_messages) lack authToken middleware, allowing unauthorized API access to sensitive message data.

## Solution

Added authToken middleware to all critical chat endpoints:
- /store_message: Requires authentication to POST messages
- /get_messages: Requires authentication to GET messages

## Security Benefits

- Enforces JWT authentication on message operations
- Prevents unauthorized message access
- Complements WebSocket security fixes
- Reduces attack surface

## Files Changed

- server/src/routes/chat.js: Added authToken middleware to message endpoints

Fixes #199