### PR TITLE
feat: add password strength indicator to registration form - scores p…

### DIFF
--- a/frontend/src/components/register/PasswordStrengthMeter.jsx
+++ b/frontend/src/components/register/PasswordStrengthMeter.jsx
@@ -1,0 +1,34 @@
+import { getPasswordStrength } from "../../utils/passwordStrength";
+
+function PasswordStrengthMeter({ password }) {
+  const { score, label, color } = getPasswordStrength(password);
+
+  if (!password) return null;
+
+  // 6 possible points total, render as 4 visual segments
+  const filledSegments = Math.ceil((score / 6) * 4);
+
+  return (
+    <div className="mt-2 space-y-1">
+      <div className="flex gap-1">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-1 flex-1 rounded-full transition-all duration-300"
+            style={{
+              background: i < filledSegments ? color : "rgba(255,255,255,0.08)",
+            }}
+          />
+        ))}
+      </div>
+      <p
+        className="text-[11px] font-semibold transition-colors duration-300"
+        style={{ color }}
+      >
+        {label} password
+      </p>
+    </div>
+  );
+}
+
+export default PasswordStrengthMeter;

--- a/frontend/src/components/register/Register.jsx
+++ b/frontend/src/components/register/Register.jsx
@@ -4,6 +4,7 @@ import AuthShell from "../auth/AuthShell";
 import { motion, AnimatePresence } from "framer-motion";
 import { FiEye, FiEyeOff } from "react-icons/fi";
 import { API_BASE_URL } from "../../config";
+import PasswordStrengthMeter from "./PasswordStrengthMeter";
 import {
   Dialog,
   DialogContent,
@@ -447,6 +448,7 @@ function Register() {
                   )}
                 </button>
               </div>
+              <PasswordStrengthMeter password={user_values.password} />
               <p className="mt-1 text-[11px]" style={{ color: "rgba(255,255,255,0.3)" }}>
                 Minimum 7 characters.
               </p>

--- a/frontend/src/utils/passwordStrength.js
+++ b/frontend/src/utils/passwordStrength.js
@@ -1,0 +1,32 @@
+// utils/passwordStrength.js
+// Scores password strength based on length and character variety.
+// Returns: { score (0-4), label ("Weak" | "Medium" | "Strong"), color }
+
+export function getPasswordStrength(password) {
+  if (!password) {
+    return { score: 0, label: "", color: "rgba(255,255,255,0.1)" };
+  }
+
+  let score = 0;
+
+  // Length factors
+  if (password.length >= 7) score++;
+  if (password.length >= 12) score++;
+
+  // Character variety factors
+  if (/[a-z]/.test(password)) score++;
+  if (/[A-Z]/.test(password)) score++;
+  if (/[0-9]/.test(password)) score++;
+  if (/[^a-zA-Z0-9]/.test(password)) score++;
+
+  // Normalize score to 0-4 scale
+  const normalized = Math.min(score, 6);
+
+  if (normalized <= 2) {
+    return { score: normalized, label: "Weak", color: "#ef4444" };
+  } else if (normalized <= 4) {
+    return { score: normalized, label: "Medium", color: "#eab308" };
+  } else {
+    return { score: normalized, label: "Strong", color: "#22c55e" };
+  }
+}


### PR DESCRIPTION
…assword based on length and character variety (upper, lower, numbers, special chars), shows live Weak/Medium/Strong meter with color-coded segments below the password field. Closes #254

## What does this PR do?
Adds a live password strength indicator to the registration form, addressing the lack of feedback users had beyond the minimum-length check. As the user types their password, a 4-segment meter fills in and color-codes (red/yellow/green) based on a scoring system that checks: length (7+ and 12+ characters), lowercase letters, uppercase letters, numbers, and special characters. A text label ("Weak password" / "Medium password" / "Strong password") updates live alongside the meter.

Implementation:
- New `utils/passwordStrength.js` — pure scoring function, returns score/label/color, fully unit-testable and decoupled from UI
- New `components/register/PasswordStrengthMeter.jsx` — renders the segmented meter and label, hidden when the field is empty
- Wired into `Register.jsx` below the existing password input, matching the existing dark/purple inline-style design system

No backend changes were needed — this is a frontend-only UX enhancement.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Testing done
- Verified meter updates live on every keystroke
- Verified meter is hidden when the password field is empty
- Verified existing registration flow (validation, OTP modal, submit) is unaffected
- Ran `npm run lint` and `npm run build` in frontend — both passed

Closes #254