### PR TITLE
feat : add edited message indicator with timestamp

### DIFF
--- a/frontend/src/components/directMessages/DirectMessage.jsx
+++ b/frontend/src/components/directMessages/DirectMessage.jsx
@@ -79,16 +79,19 @@ function DirectMessage() {
         }
 
         return [
-          ...currentMessages,
-          {
-            sender_id: message.sender_id,
-            sender_name: message.sender_name,
-            sender_tag: message.sender_tag,
-            sender_pic: message.sender_pic,
-            content: message.content,
-            timestamp: message.timestamp,
-          },
-        ];
+  ...currentMessages,
+  {
+    sender_id: message.sender_id,
+    sender_name: message.sender_name,
+    sender_tag: message.sender_tag,
+    sender_pic: message.sender_pic,
+    content: message.content,
+    timestamp: message.timestamp,
+
+    edited: message.edited ?? false,
+    editedAt: message.editedAt ?? null,
+  },
+];
       });
     };
 
@@ -98,13 +101,18 @@ function DirectMessage() {
       }
 
       setMessages((currentMessages) =>
-        currentMessages.map((entry) =>
-          String(entry.timestamp) === String(message.timestamp) &&
-          entry.sender_id === message.friend_id
-            ? { ...entry, content: message.content }
-            : entry
-        )
-      );
+  currentMessages.map((entry) =>
+    String(entry.timestamp) === String(message.timestamp) &&
+    entry.sender_id === message.sender_id
+      ? {
+          ...entry,
+          content: message.content,
+          edited: message.edited,
+          editedAt: message.editedAt,
+        }
+      : entry
+  )
+);
     };
 
     const handleDeletedMessage = (message) => {
@@ -214,7 +222,12 @@ function DirectMessage() {
         currentMessages.map((entry) =>
           String(entry.timestamp) === String(message.timestamp) &&
           entry.sender_id === currentUser.id
-            ? { ...entry, content: editingContent.trim() }
+            ? {
+    ...entry,
+    content: editingContent.trim(),
+    edited: true,
+    editedAt: Date.now(),
+  }
             : entry
         )
       );
@@ -327,15 +340,26 @@ function DirectMessage() {
                   ) : (
                     <div className="relative mt-2">
                       <div
-                        className={[
-                          "rounded-2xl border px-3 py-2 text-sm leading-relaxed",
-                          mine
-                            ? "border-brand-400/20 bg-brand-400/10 text-white"
-                            : "border-white/10 bg-white/5 text-white/85",
-                        ].join(" ")}
-                      >
-                        {message.content}
-                      </div>
+  className={[
+    "rounded-2xl border px-3 py-2 text-sm leading-relaxed",
+    mine
+      ? "border-brand-400/20 bg-brand-400/10 text-white"
+      : "border-white/10 bg-white/5 text-white/85",
+  ].join(" ")}
+>
+  <div className="flex items-center gap-2 flex-wrap">
+    <span>{message.content}</span>
+
+    {message.edited && (
+      <span
+        className="rounded bg-white/10 px-1 py-0.5 text-[10px] text-white/60"
+        title={`Edited at ${new Date(message.editedAt).toLocaleString()}`}
+      >
+        Edited
+      </span>
+    )}
+  </div>
+</div>
 
                       {mine ? (
                         <div

--- a/server/src/models/DirectMessageThread.js
+++ b/server/src/models/DirectMessageThread.js
@@ -10,8 +10,21 @@ const directMessageThreadSchema = new mongoose.Schema({
       sender_pic: String,
       content: String,
       timestamp: Number,
+
+      edited: {
+        type: Boolean,
+        default: false,
+      },
+
+      editedAt: {
+        type: Number,
+        default: null,
+      },
     },
   ],
 });
 
-export default mongoose.model("direct_message_threads", directMessageThreadSchema);
+export default mongoose.model(
+  "direct_message_threads",
+  directMessageThreadSchema
+);

--- a/server/src/routes/directMessages.js
+++ b/server/src/routes/directMessages.js
@@ -95,13 +95,16 @@ router.post("/send_direct_message", sendDirectMessageValidator, validate, async 
   const friendUserId = String(friend._id);
 
   const message = {
-    sender_id: currentUserId,
-    sender_name: currentUser.username,
-    sender_tag: currentUser.tag,
-    sender_pic: currentUser.profile_pic,
-    content: content.trim(),
-    timestamp: Date.now(),
-  };
+  sender_id: currentUserId,
+  sender_name: currentUser.username,
+  sender_tag: currentUser.tag,
+  sender_pic: currentUser.profile_pic,
+  content: content.trim(),
+  timestamp: Date.now(),
+
+  edited: false,
+  editedAt: null,
+};
 
   const participants = getThreadParticipants(currentUserId, friendUserId);
 
@@ -119,23 +122,29 @@ router.post("/send_direct_message", sendDirectMessageValidator, validate, async 
   if (io) {
     await incrementDmUnread(friendUserId, currentUserId);
     io.to(friendUserId).emit("direct_message_received", {
-      friend_id: currentUserId,
-      sender_id: currentUserId,
-      sender_name: currentUser.username,
-      sender_tag: currentUser.tag,
-      sender_pic: currentUser.profile_pic,
-      content: message.content,
-      timestamp: message.timestamp,
-    });
+  friend_id: currentUserId,
+  sender_id: currentUserId,
+  sender_name: currentUser.username,
+  sender_tag: currentUser.tag,
+  sender_pic: currentUser.profile_pic,
+  content: message.content,
+  timestamp: message.timestamp,
+
+  edited: message.edited,
+  editedAt: message.editedAt,
+});
     io.to(currentUserId).emit("direct_message_received", {
-      friend_id: friendUserId,
-      sender_id: currentUserId,
-      sender_name: currentUser.username,
-      sender_tag: currentUser.tag,
-      sender_pic: currentUser.profile_pic,
-      content: message.content,
-      timestamp: message.timestamp,
-    });
+  friend_id: friendUserId,
+  sender_id: currentUserId,
+  sender_name: currentUser.username,
+  sender_tag: currentUser.tag,
+  sender_pic: currentUser.profile_pic,
+  content: message.content,
+  timestamp: message.timestamp,
+
+  edited: message.edited,
+  editedAt: message.editedAt,
+});
     const shouldNotify = await shouldSendNotification(friendUserId, "direct_messages");
     if (shouldNotify) {
       io.to(friendUserId).emit("direct_message_notification", {
@@ -176,7 +185,11 @@ router.post("/edit_direct_message", editDirectMessageValidator, validate, async 
   }
 
   message.content = content.trim();
-  await thread.save();
+
+message.edited = true;
+message.editedAt = Date.now();
+
+await thread.save();
   await cache.del(`dm:${participants[0]}:${participants[1]}`);
 
   const io = getIO();
@@ -228,15 +241,15 @@ router.post("/delete_direct_message", deleteDirectMessageValidator, validate, as
   const io = getIO();
   if (io) {
     io.to(friend_id).emit("direct_message_deleted", {
-      friend_id: user.id,
-      timestamp,
-      sender_id: user.id,
-    });
+  friend_id: user.id,
+  timestamp,
+  sender_id: user.id,
+});
     io.to(user.id).emit("direct_message_deleted", {
-      friend_id,
-      timestamp,
-      sender_id: user.id,
-    });
+  friend_id,
+  timestamp,
+  sender_id: user.id,
+});
   }
 
   return res.status(200).json({ status: 200, message: "Message deleted" });


### PR DESCRIPTION
## Summary

- Added edited and editedAt fields to direct messages.
- Display an Edited badge after a message is edited.
- Show the edit timestamp on hover.
- Synced edited state through socket events.
- Preserved message order and existing functionality.

## Testing

- Sent new messages
- Edited messages
- Verified badge and timestamp
- Tested sender and receiver synchronization
- Refreshed pages to verify persistence