### PR TITLE
Fix: Message reactions not syncing across devices

### DIFF
--- a/frontend/src/components/chat/messages/ValidChat.jsx
+++ b/frontend/src/components/chat/messages/ValidChat.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Hash, Pencil, Trash2, Save, SendHorizontal, Loader2, AlertCircle, Pin } from "lucide-react";
+import { Hash, Pencil, Trash2, Save, SendHorizontal, Loader2, AlertCircle, Pin, SmilePlus } from "lucide-react";
 import socket from "../../socket/Socket";
 import { useParams } from "react-router-dom";
 import { clear_channel_unread } from "../../../store/unreadSlice";
@@ -33,6 +33,7 @@ function ValidChat() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [typingUsers, setTypingUsers] = useState({});
+  const [reactionPopup, setReactionPopup] = useState(null);
   const messagesEndRef = useRef(null);
   const typingTimeoutRef = useRef(null);
   const typingUserTimeoutsRef = useRef({});
@@ -230,6 +231,27 @@ function ValidChat() {
     }
   };
 
+  const toggleReaction = async (message, emoji) => {
+    try {
+      await fetch(`${url}/chat/toggle_reaction`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-auth-token": localStorage.getItem("token"),
+        },
+        body: JSON.stringify({
+          server_id,
+          channel_id,
+          timestamp: message.timestamp,
+          sender_id: message.sender_id,
+          emoji,
+        }),
+      });
+    } catch (err) {
+      console.error("Failed to toggle reaction:", err);
+    }
+  };
+
   const togglePinMessage = async (message) => {
     const res = await fetch(`${url}/chat/toggle_server_message_pin`, {
       method: "POST",
@@ -318,6 +340,17 @@ function ValidChat() {
       );
     };
 
+    const handleReactionUpdated = (message_data) => {
+      setall_messages((currentMessages) =>
+        (currentMessages || []).map((entry) =>
+          String(entry.timestamp) === String(message_data.timestamp) &&
+          entry.sender_id === message_data.sender_id
+            ? { ...entry, reactions: message_data.reactions }
+            : entry
+        )
+      );
+    };
+
     const handleTyping = (typingData) => {
       if (
         String(typingData?.server_id) !== String(server_id) ||
@@ -365,6 +398,7 @@ function ValidChat() {
     socket.on("server_message_updated", handleUpdatedMessage);
     socket.on("server_message_deleted", handleDeletedMessage);
     socket.on("server_message_pin_updated", handlePinUpdatedMessage);
+    socket.on("server_message_reaction_updated", handleReactionUpdated);
     socket.on("server_typing", handleTyping);
     socket.on("server_stop_typing", handleStopTyping);
 
@@ -373,6 +407,7 @@ function ValidChat() {
       socket.off("server_message_updated", handleUpdatedMessage);
       socket.off("server_message_deleted", handleDeletedMessage);
       socket.off("server_message_pin_updated", handlePinUpdatedMessage);
+      socket.off("server_message_reaction_updated", handleReactionUpdated);
       socket.off("server_typing", handleTyping);
       socket.off("server_stop_typing", handleStopTyping);
       Object.values(typingUserTimeoutsRef.current).forEach(clearTimeout);
@@ -543,6 +578,49 @@ function ValidChat() {
                       {elem.content}
                     </div>
                   )}
+
+                  <div className="mt-1 flex flex-wrap items-center gap-1">
+                    {elem.reactions && typeof elem.reactions === 'object' && Object.entries(elem.reactions).map(([emoji, reactors]) => (
+                      <button
+                        key={emoji}
+                        type="button"
+                        onClick={() => toggleReaction(elem, emoji)}
+                        className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs border transition ${
+                          reactors.includes(id)
+                            ? "bg-brand-300/20 border-brand-300/40 text-brand-200"
+                            : "border-white/10 text-white/50 hover:bg-white/5"
+                        }`}
+                      >
+                        {emoji} {reactors.length}
+                      </button>
+                    ))}
+                    <div className="relative">
+                      <button
+                        type="button"
+                        onClick={() => setReactionPopup(reactionPopup === elem.timestamp ? null : elem.timestamp)}
+                        className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs border border-white/10 text-white/50 hover:bg-white/5 transition"
+                      >
+                        <SmilePlus className="h-3 w-3" />
+                      </button>
+                      {reactionPopup === elem.timestamp && (
+                        <div className="absolute bottom-full left-0 mb-1 flex gap-1 rounded-lg border border-white/10 bg-gray-900 p-1.5 shadow-lg z-50">
+                          {["👍", "❤️", "😂", "😮", "😢", "🔥"].map((emoji) => (
+                            <button
+                              key={emoji}
+                              type="button"
+                              className="rounded p-1 text-lg hover:bg-white/10 transition"
+                              onClick={() => {
+                                toggleReaction(elem, emoji);
+                                setReactionPopup(null);
+                              }}
+                            >
+                              {emoji}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
                 </div>
               </div>
             );

--- a/server/src/models/Chat.js
+++ b/server/src/models/Chat.js
@@ -15,6 +15,7 @@ const chatSchema = new mongoose.Schema({
           sender_tag: String,
           timestamp: String,
           is_pinned: { type: Boolean, default: false },
+          reactions: { type: Map, of: [String], default: {} },
         },
       ],
     },

--- a/server/src/routes/chat.js
+++ b/server/src/routes/chat.js
@@ -377,4 +377,74 @@ router.post("/delete_server_message", deleteServerMessageValidator, validate, as
   }
 });
 
+router.post("/toggle_reaction", async (req, res) => {
+  const { server_id, channel_id, timestamp, sender_id, emoji } = req.body;
+  const user = getAuthorizedUser(req, res);
+  if (!user) return;
+
+  if (!server_id || !channel_id || !timestamp || !sender_id || !emoji) {
+    return res.status(400).json({ status: 400, message: "Invalid input" });
+  }
+
+  try {
+    const chatDoc = await Chat.findOne({
+      server_id,
+      "channels.channel_id": channel_id,
+    });
+    if (!chatDoc) {
+      return res.status(404).json({ status: 404, message: "Chat not found" });
+    }
+
+    const channel = chatDoc.channels.find(
+      (entry) => entry.channel_id === channel_id,
+    );
+    const message = findChatMessage(channel, timestamp, sender_id);
+    if (!message) {
+      return res.status(404).json({ status: 404, message: "Message not found" });
+    }
+
+    if (!message.reactions) {
+      message.reactions = {};
+    }
+
+    const reactors = message.reactions[emoji] || [];
+    const userId = user.id;
+    const idx = reactors.indexOf(userId);
+
+    if (idx === -1) {
+      reactors.push(userId);
+    } else {
+      reactors.splice(idx, 1);
+    }
+
+    if (reactors.length === 0) {
+      delete message.reactions[emoji];
+    } else {
+      message.reactions[emoji] = reactors;
+    }
+
+    await chatDoc.save();
+    await cache.del(`chat:${server_id}:${channel_id}`);
+
+    const io = getIO();
+    if (io) {
+      io.to(`channel:${channel_id}`).emit("server_message_reaction_updated", {
+        timestamp,
+        sender_id,
+        emoji,
+        reactors: message.reactions[emoji] || [],
+        reactions: message.reactions || {},
+      });
+    }
+
+    res.status(200).json({
+      status: 200,
+      reactions: message.reactions || {},
+    });
+  } catch (error) {
+    logger.error(`Error toggling reaction: ${error.message}`);
+    res.status(500).json({ status: 500, message: "Failed to toggle reaction" });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Description
Message reactions added on one device now sync across all devices in real time.

## Changes
- Added `reactions` field to the Chat model (Map of emoji → user ID array)
- Added `POST /chat/toggle_reaction` API endpoint with server-side persistence
- Added `server_message_reaction_updated` socket event for real-time sync
- Added reaction picker UI (SmilePlus button) with 6 emoji options
- Reactions show real-time counts and highlight if current user has reacted
- All reaction state is persisted in MongoDB and synced via Socket.IO

Fixes #140